### PR TITLE
feat: add ECIES property value encryption

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     env:
       project-path: ./Example
-      simulator: iOS Simulator,OS=latest,name=iPhone 16
+      simulator: iOS Simulator,OS=latest,name=iPhone 15
 
     steps:
       - name: Checkout repository

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ DerivedData
 
 Carthage/Build
 
+# Local overrides (not checked in)
+LocalConfig.h
+
 # We recommend against adding the Pods directory to your .gitignore. However
 # you should judge for yourself, the pros and cons are mentioned at:
 # https://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control

--- a/AvoInspector/Classes/AvoBatcher.h
+++ b/AvoInspector/Classes/AvoBatcher.h
@@ -20,6 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void) handleTrackSchema: (NSString *) eventName schema: (NSDictionary<NSString *, AvoEventSchemaType *> *) schema eventId:(NSString * _Nullable) eventId eventHash:(NSString * _Nullable) eventHash;
 
+- (void) handleTrackSchema: (NSString *) eventName schema: (NSDictionary<NSString *, AvoEventSchemaType *> *) schema eventId:(NSString * _Nullable) eventId eventHash:(NSString * _Nullable) eventHash eventProperties:(NSDictionary * _Nullable) eventProperties;
+
 - (void) enterBackground;
 - (void) enterForeground;
 

--- a/AvoInspector/Classes/AvoBatcher.m
+++ b/AvoInspector/Classes/AvoBatcher.m
@@ -68,22 +68,32 @@
 // schema is [ String : AvoEventSchemaType ]
 - (void) handleTrackSchema: (NSString *) eventName schema: (NSDictionary<NSString *, AvoEventSchemaType *> *) schema eventId:(NSString *) eventId eventHash:(NSString *) eventHash {
     NSMutableDictionary * trackSchemaBody = [self.networkCallsHandler bodyForTrackSchemaCall:eventName schema: schema eventId: eventId eventHash: eventHash];
-    
+
+    [self saveAndLogEvent:trackSchemaBody schema:schema eventName:eventName];
+}
+
+- (void) handleTrackSchema: (NSString *) eventName schema: (NSDictionary<NSString *, AvoEventSchemaType *> *) schema eventId:(NSString *) eventId eventHash:(NSString *) eventHash eventProperties:(NSDictionary * _Nullable) eventProperties {
+    NSMutableDictionary * trackSchemaBody = [self.networkCallsHandler bodyForTrackSchemaCall:eventName schema: schema eventId: eventId eventHash: eventHash eventProperties: eventProperties];
+
+    [self saveAndLogEvent:trackSchemaBody schema:schema eventName:eventName];
+}
+
+- (void) saveAndLogEvent:(NSMutableDictionary *)trackSchemaBody schema:(NSDictionary<NSString *, AvoEventSchemaType *> *)schema eventName:(NSString *)eventName {
     [self saveEvent:trackSchemaBody];
-    
+
     if ([AvoInspector isLogging]) {
-        
+
         NSString * schemaString = @"";
-        
+
         for(NSString *key in [schema allKeys]) {
             NSString *value = [[schema objectForKey:key] name];
             NSString *entry = [NSString stringWithFormat:@"\t\"%@\": \"%@\";\n", key, value];
             schemaString = [schemaString stringByAppendingString:entry];
         }
-        
+
         NSLog(@"[avo] Avo Inspector: Saved event %@ with schema {\n%@}", eventName, schemaString);
     }
-    
+
     [self checkIfBatchNeedsToBeSent];
 }
 

--- a/AvoInspector/Classes/AvoEncryption.h
+++ b/AvoInspector/Classes/AvoEncryption.h
@@ -1,0 +1,35 @@
+//
+//  AvoEncryption.h
+//  AvoInspector
+//
+//  ECIES encryption (P-256 + AES-256-GCM) for property value encryption.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface AvoEncryption : NSObject
+
+/**
+ Encrypts plaintext using ECIES (Elliptic Curve Integrated Encryption Scheme).
+
+ Algorithm:
+ 1. Parse recipient public key from hex (compressed or uncompressed)
+ 2. Generate ephemeral P-256 keypair
+ 3. ECDH shared secret
+ 4. KDF: SHA-256(sharedSecret) -> 32-byte AES key
+ 5. AES-256-GCM encrypt with random 16-byte IV
+ 6. Serialize: [Version(1)] + [EphemeralPubKey(65)] + [IV(16)] + [AuthTag(16)] + [Ciphertext]
+ 7. Base64 encode
+
+ @param plaintext The string to encrypt
+ @param recipientPublicKeyHex The recipient's EC public key in hex (compressed or uncompressed)
+ @return Base64-encoded ciphertext, or nil on any error
+ */
++ (NSString * _Nullable)encrypt:(NSString * _Nullable)plaintext
+         recipientPublicKeyHex:(NSString * _Nullable)recipientPublicKeyHex;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AvoInspector/Classes/AvoEncryption.m
+++ b/AvoInspector/Classes/AvoEncryption.m
@@ -10,10 +10,18 @@
 #import <CommonCrypto/CommonCrypto.h>
 #import <CommonCrypto/CommonCryptor.h>
 
-// Forward-declare GCM functions that are in CommonCrypto but not always in public headers
-extern CCCryptorStatus CCCryptorGCMSetIV(CCCryptorRef cryptorRef, const void *iv, size_t ivLen);
-extern CCCryptorStatus CCCryptorGCMEncrypt(CCCryptorRef cryptorRef, const void *dataIn, size_t dataInLength, void *dataOut);
-extern CCCryptorStatus CCCryptorGCMFinalize(CCCryptorRef cryptorRef, void *tagOut, size_t tagLength);
+// AES-GCM oneshot API from CommonCrypto. These are stable, exported symbols in libcommonCrypto
+// (present since iOS 6) but not declared in the public <CommonCrypto/CommonCryptor.h> header.
+// Apple's public alternative, CryptoKit, is Swift-only and cannot be called from Objective-C
+// without a bridging layer. Forward-declaring is the standard approach for ObjC AES-GCM.
+extern CCCryptorStatus CCCryptorGCMOneshotEncrypt(
+    CCAlgorithm alg,
+    const void *key, size_t keyLength,
+    const void *iv, size_t ivLength,
+    const void *aad, size_t aadLength,
+    const void *dataIn, size_t dataInLength,
+    void *dataOut,
+    void *tagOut, size_t tagLength);
 
 // AES-GCM constants
 static const NSInteger kIVLength = 16;
@@ -524,42 +532,14 @@ static const uint8_t secp256r1_p_plus1_div4[32] = {
                     iv:(NSData *)iv
             ciphertext:(NSMutableData *)ciphertext
                authTag:(NSMutableData *)authTag {
-    // Use step-by-step CCCryptorGCM API for broad iOS compatibility
-    CCCryptorRef cryptorRef = NULL;
-    CCCryptorStatus status;
-
-    status = CCCryptorCreateWithMode(kCCEncrypt,
-                                      11, // kCCModeGCM = 11
-                                      kCCAlgorithmAES,
-                                      ccNoPadding,
-                                      NULL, // iv set separately for GCM
-                                      key.bytes,
-                                      key.length,
-                                      NULL, 0, 0, 0,
-                                      &cryptorRef);
-    if (status != kCCSuccess || cryptorRef == NULL) {
-        return NO;
-    }
-
-    // Set IV using CCCryptorGCMSetIV
-    status = CCCryptorGCMSetIV(cryptorRef, iv.bytes, iv.length);
-    if (status != kCCSuccess) {
-        CCCryptorRelease(cryptorRef);
-        return NO;
-    }
-
-    // Encrypt
-    status = CCCryptorGCMEncrypt(cryptorRef, plaintext.bytes, plaintext.length, ciphertext.mutableBytes);
-    if (status != kCCSuccess) {
-        CCCryptorRelease(cryptorRef);
-        return NO;
-    }
-
-    // Finalize and get auth tag
-    size_t tagLength = kAuthTagLength;
-    status = CCCryptorGCMFinalize(cryptorRef, authTag.mutableBytes, tagLength);
-    CCCryptorRelease(cryptorRef);
-
+    CCCryptorStatus status = CCCryptorGCMOneshotEncrypt(
+        kCCAlgorithmAES,
+        key.bytes, key.length,
+        iv.bytes, iv.length,
+        NULL, 0,  // no AAD
+        plaintext.bytes, plaintext.length,
+        ciphertext.mutableBytes,
+        authTag.mutableBytes, kAuthTagLength);
     return status == kCCSuccess;
 }
 

--- a/AvoInspector/Classes/AvoEncryption.m
+++ b/AvoInspector/Classes/AvoEncryption.m
@@ -1,0 +1,566 @@
+//
+//  AvoEncryption.m
+//  AvoInspector
+//
+//  ECIES encryption (P-256 + AES-256-GCM) for property value encryption.
+//
+
+#import "AvoEncryption.h"
+#import <Security/Security.h>
+#import <CommonCrypto/CommonCrypto.h>
+#import <CommonCrypto/CommonCryptor.h>
+
+// Forward-declare GCM functions that are in CommonCrypto but not always in public headers
+extern CCCryptorStatus CCCryptorGCMSetIV(CCCryptorRef cryptorRef, const void *iv, size_t ivLen);
+extern CCCryptorStatus CCCryptorGCMEncrypt(CCCryptorRef cryptorRef, const void *dataIn, size_t dataInLength, void *dataOut);
+extern CCCryptorStatus CCCryptorGCMFinalize(CCCryptorRef cryptorRef, void *tagOut, size_t tagLength);
+
+// AES-GCM constants
+static const NSInteger kIVLength = 16;
+static const NSInteger kAuthTagLength = 16;
+static const NSInteger kUncompressedKeyLength = 65;
+static const NSInteger kVersionByteLength = 1;
+static const uint8_t kVersionByte = 0x00;
+
+@implementation AvoEncryption
+
+#pragma mark - Public API
+
++ (NSString * _Nullable)encrypt:(NSString * _Nullable)plaintext
+         recipientPublicKeyHex:(NSString * _Nullable)recipientPublicKeyHex {
+    @try {
+        if (plaintext == nil || recipientPublicKeyHex == nil || recipientPublicKeyHex.length == 0) {
+            return nil;
+        }
+
+        // 1. Parse recipient public key from hex
+        NSData *pubKeyBytes = [self hexToBytes:recipientPublicKeyHex];
+        if (pubKeyBytes == nil) {
+            return nil;
+        }
+
+        NSData *uncompressedPubKeyData = [self parseAndUncompressPublicKey:pubKeyBytes];
+        if (uncompressedPubKeyData == nil) {
+            return nil;
+        }
+
+        SecKeyRef recipientKey = [self createECPublicKeyFromUncompressedData:uncompressedPubKeyData];
+        if (recipientKey == NULL) {
+            return nil;
+        }
+
+        // 2. Generate ephemeral P-256 keypair
+        SecKeyRef ephemeralPrivateKey = NULL;
+        SecKeyRef ephemeralPublicKey = NULL;
+        BOOL keyGenOk = [self generateEphemeralKeyPairPrivate:&ephemeralPrivateKey public:&ephemeralPublicKey];
+        if (!keyGenOk) {
+            CFRelease(recipientKey);
+            return nil;
+        }
+
+        // 3. ECDH shared secret
+        NSData *sharedSecret = [self computeECDHSharedSecret:ephemeralPrivateKey withPublicKey:recipientKey];
+        CFRelease(recipientKey);
+        if (sharedSecret == nil) {
+            CFRelease(ephemeralPrivateKey);
+            CFRelease(ephemeralPublicKey);
+            return nil;
+        }
+
+        // 4. KDF: SHA-256(sharedSecret) -> 32-byte AES key
+        NSData *aesKey = [self sha256:sharedSecret];
+
+        // 5. Generate random IV
+        NSMutableData *iv = [NSMutableData dataWithLength:kIVLength];
+        int result = SecRandomCopyBytes(kSecRandomDefault, kIVLength, iv.mutableBytes);
+        if (result != errSecSuccess) {
+            CFRelease(ephemeralPrivateKey);
+            CFRelease(ephemeralPublicKey);
+            return nil;
+        }
+
+        // 6. AES-256-GCM encrypt
+        NSData *plaintextData = [plaintext dataUsingEncoding:NSUTF8StringEncoding];
+        NSMutableData *ciphertext = [NSMutableData dataWithLength:plaintextData.length];
+        NSMutableData *authTag = [NSMutableData dataWithLength:kAuthTagLength];
+
+        BOOL encryptOk = [self aesGcmEncrypt:plaintextData
+                                         key:aesKey
+                                          iv:iv
+                                  ciphertext:ciphertext
+                                     authTag:authTag];
+        CFRelease(ephemeralPrivateKey);
+
+        if (!encryptOk) {
+            CFRelease(ephemeralPublicKey);
+            return nil;
+        }
+
+        // 7. Encode ephemeral public key as uncompressed point
+        NSData *ephemeralPubData = [self exportUncompressedPublicKey:ephemeralPublicKey];
+        CFRelease(ephemeralPublicKey);
+        if (ephemeralPubData == nil || ephemeralPubData.length != kUncompressedKeyLength) {
+            return nil;
+        }
+
+        // 8. Assemble: [Version(1)] + [EphemeralPubKey(65)] + [IV(16)] + [AuthTag(16)] + [Ciphertext]
+        NSMutableData *output = [NSMutableData dataWithCapacity:
+                                 kVersionByteLength + kUncompressedKeyLength + kIVLength + kAuthTagLength + ciphertext.length];
+        uint8_t version = kVersionByte;
+        [output appendBytes:&version length:1];
+        [output appendData:ephemeralPubData];
+        [output appendData:iv];
+        [output appendData:authTag];
+        [output appendData:ciphertext];
+
+        // 9. Base64 encode (no line breaks)
+        return [output base64EncodedStringWithOptions:0];
+    }
+    @catch (NSException *exception) {
+        NSLog(@"[avo] Avo Inspector: Encryption failed: %@", exception);
+        return nil;
+    }
+}
+
+#pragma mark - Key Parsing
+
++ (NSData * _Nullable)hexToBytes:(NSString *)hex {
+    if (hex == nil || hex.length == 0) {
+        return nil;
+    }
+
+    // Remove 0x prefix if present
+    if ([hex hasPrefix:@"0x"] || [hex hasPrefix:@"0X"]) {
+        hex = [hex substringFromIndex:2];
+    }
+
+    if (hex.length % 2 != 0) {
+        return nil;
+    }
+
+    NSMutableData *data = [NSMutableData dataWithCapacity:hex.length / 2];
+    for (NSUInteger i = 0; i < hex.length; i += 2) {
+        NSString *byteString = [hex substringWithRange:NSMakeRange(i, 2)];
+        unsigned int byteValue;
+        NSScanner *scanner = [NSScanner scannerWithString:byteString];
+        if (![scanner scanHexInt:&byteValue]) {
+            return nil;
+        }
+        uint8_t byte = (uint8_t)byteValue;
+        [data appendBytes:&byte length:1];
+    }
+    return data;
+}
+
++ (NSData * _Nullable)parseAndUncompressPublicKey:(NSData *)pubKeyBytes {
+    const uint8_t *bytes = pubKeyBytes.bytes;
+    NSUInteger length = pubKeyBytes.length;
+
+    if (length == 33 && (bytes[0] == 0x02 || bytes[0] == 0x03)) {
+        // Compressed key: prefix (1 byte) + X (32 bytes)
+        return [self decompressPublicKey:pubKeyBytes];
+    } else if (length == 65 && bytes[0] == 0x04) {
+        // Uncompressed with 0x04 prefix
+        return pubKeyBytes;
+    } else if (length == 64) {
+        // Raw X + Y without prefix, add 0x04
+        NSMutableData *uncompressed = [NSMutableData dataWithCapacity:65];
+        uint8_t prefix = 0x04;
+        [uncompressed appendBytes:&prefix length:1];
+        [uncompressed appendData:pubKeyBytes];
+        return uncompressed;
+    }
+
+    return nil;
+}
+
++ (NSData * _Nullable)decompressPublicKey:(NSData *)compressedKey {
+    const uint8_t *bytes = compressedKey.bytes;
+    BOOL yOdd = (bytes[0] == 0x03);
+
+    // Extract X coordinate (32 bytes after prefix)
+    NSData *xData = [compressedKey subdataWithRange:NSMakeRange(1, 32)];
+
+    // secp256r1 curve parameters
+    // p = FFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFF
+    // a = FFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFC
+    // b = 5AC635D8AA3A93E7B3EBBD55769886BC651D06B0CC53B0F63BCE3C3E27D2604B
+
+    // We need to compute Y from X using the curve equation: y^2 = x^3 + ax + b (mod p)
+    // For secp256r1, p ≡ 3 (mod 4), so y = (y^2)^((p+1)/4) mod p
+
+    // Use OpenSSL-free big number arithmetic via SecKey
+    // Strategy: create a temporary key with both coordinates to validate,
+    // using the mathematical approach with CC_SHA256 for big number ops.
+
+    // Actually, the simplest approach on iOS is to use the curve equation directly
+    // with big number arithmetic. Since we don't have a BigInteger class,
+    // we'll implement modular arithmetic on byte arrays.
+
+    NSData *yData = [self computeYFromX:xData yOdd:yOdd];
+    if (yData == nil) {
+        return nil;
+    }
+
+    // Build uncompressed point: 0x04 + X(32) + Y(32)
+    NSMutableData *uncompressed = [NSMutableData dataWithCapacity:65];
+    uint8_t prefix = 0x04;
+    [uncompressed appendBytes:&prefix length:1];
+    [uncompressed appendData:xData];
+    [uncompressed appendData:yData];
+    return uncompressed;
+}
+
+// Big number arithmetic for secp256r1 Y-coordinate recovery
+// All numbers are 32-byte big-endian unsigned integers
+
+// secp256r1 prime p
+static const uint8_t secp256r1_p[32] = {
+    0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x01,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
+};
+
+// secp256r1 a = p - 3
+static const uint8_t secp256r1_a[32] = {
+    0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x01,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFC
+};
+
+// secp256r1 b
+static const uint8_t secp256r1_b[32] = {
+    0x5A, 0xC6, 0x35, 0xD8, 0xAA, 0x3A, 0x93, 0xE7,
+    0xB3, 0xEB, 0xBD, 0x55, 0x76, 0x98, 0x86, 0xBC,
+    0x65, 0x1D, 0x06, 0xB0, 0xCC, 0x53, 0xB0, 0xF6,
+    0x3B, 0xCE, 0x3C, 0x3E, 0x27, 0xD2, 0x60, 0x4B
+};
+
+// (p + 1) / 4 — used for modular square root since p ≡ 3 (mod 4)
+static const uint8_t secp256r1_p_plus1_div4[32] = {
+    0x3F, 0xFF, 0xFF, 0xFF, 0xC0, 0x00, 0x00, 0x00,
+    0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+};
+
+// Modular multiplication: (a * b) mod p using 64-byte intermediate
++ (void)bigMulMod:(const uint8_t *)a b:(const uint8_t *)b p:(const uint8_t *)p result:(uint8_t *)result {
+    // Compute a * b into a 64-byte buffer
+    uint8_t product[64];
+    memset(product, 0, 64);
+
+    for (int i = 31; i >= 0; i--) {
+        uint16_t carry = 0;
+        for (int j = 31; j >= 0; j--) {
+            uint32_t val = (uint32_t)product[i + j + 1] + (uint32_t)a[i] * (uint32_t)b[j] + carry;
+            product[i + j + 1] = (uint8_t)(val & 0xFF);
+            carry = (uint16_t)(val >> 8);
+        }
+        product[i] += (uint8_t)carry;
+    }
+
+    // Reduce product mod p
+    [self bigMod:product len:64 p:p result:result];
+}
+
+// Modular reduction: num (len bytes, big-endian) mod p (32 bytes) -> result (32 bytes)
+// Uses schoolbook byte-by-byte long division with repeated subtraction.
++ (void)bigMod:(const uint8_t *)num len:(int)len p:(const uint8_t *)p result:(uint8_t *)result {
+    // 33-byte accumulator: one extra byte for overflow during shift
+    uint8_t remainder[33];
+    memset(remainder, 0, 33);
+
+    for (int i = 0; i < len; i++) {
+        // remainder = (remainder << 8) | num[i]
+        for (int j = 0; j < 32; j++) {
+            remainder[j] = remainder[j + 1];
+        }
+        remainder[32] = num[i];
+
+        // Reduce: while remainder >= p, subtract p
+        while ([self bigCompare33:remainder p:p] >= 0) {
+            [self bigSub33:remainder p:p];
+        }
+    }
+
+    // Result is in remainder[1..32]
+    memcpy(result, remainder + 1, 32);
+}
+
++ (int)bigCompare33:(const uint8_t *)a p:(const uint8_t *)p {
+    // Compare 33-byte a with 32-byte p (p has implicit leading zero)
+    if (a[0] != 0) return 1; // a has a non-zero 33rd byte, so a > p
+    return [self bigCompare:a + 1 len:32 p:p];
+}
+
++ (void)bigSub33:(uint8_t *)a p:(const uint8_t *)p {
+    // Subtract 32-byte p from 33-byte a, result in a
+    int16_t borrow = 0;
+    for (int i = 32; i >= 1; i--) {
+        int16_t diff = (int16_t)a[i] - (int16_t)p[i - 1] - borrow;
+        if (diff < 0) {
+            diff += 256;
+            borrow = 1;
+        } else {
+            borrow = 0;
+        }
+        a[i] = (uint8_t)diff;
+    }
+    a[0] = (uint8_t)((int16_t)a[0] - borrow);
+}
+
++ (int)bigCompare:(const uint8_t *)a len:(int)aLen p:(const uint8_t *)p {
+    // Compare a (aLen bytes) with p (32 bytes)
+    // Skip leading zeros in a
+    int aStart = 0;
+    while (aStart < aLen - 32 && a[aStart] == 0) aStart++;
+
+    if (aLen - aStart > 32) return 1;
+    if (aLen - aStart < 32) return -1;
+
+    for (int i = 0; i < 32; i++) {
+        if (a[aStart + i] > p[i]) return 1;
+        if (a[aStart + i] < p[i]) return -1;
+    }
+    return 0;
+}
+
+// Modular addition: (a + b) mod p, all 32 bytes
++ (void)bigAddMod:(const uint8_t *)a b:(const uint8_t *)b p:(const uint8_t *)p result:(uint8_t *)result {
+    uint16_t carry = 0;
+    uint8_t sum[33];
+    sum[0] = 0;
+    for (int i = 31; i >= 0; i--) {
+        uint16_t s = (uint16_t)a[i] + (uint16_t)b[i] + carry;
+        sum[i + 1] = (uint8_t)(s & 0xFF);
+        carry = s >> 8;
+    }
+    sum[0] = (uint8_t)carry;
+
+    // Reduce mod p
+    while ([self bigCompare33:sum p:p] >= 0) {
+        [self bigSub33:sum p:p];
+    }
+    memcpy(result, sum + 1, 32);
+}
+
+// Modular exponentiation: base^exp mod p (all 32 bytes)
++ (void)bigModPow:(const uint8_t *)base exp:(const uint8_t *)exp p:(const uint8_t *)p result:(uint8_t *)result {
+    uint8_t r[32];
+    memset(r, 0, 32);
+    r[31] = 1; // r = 1
+
+    uint8_t b[32];
+    memcpy(b, base, 32);
+
+    // Square-and-multiply from LSB
+    for (int byteIdx = 31; byteIdx >= 0; byteIdx--) {
+        for (int bitIdx = 0; bitIdx < 8; bitIdx++) {
+            if ((exp[byteIdx] >> bitIdx) & 1) {
+                uint8_t temp[32];
+                [self bigMulMod:r b:b p:p result:temp];
+                memcpy(r, temp, 32);
+            }
+            uint8_t temp2[32];
+            [self bigMulMod:b b:b p:p result:temp2];
+            memcpy(b, temp2, 32);
+        }
+    }
+
+    memcpy(result, r, 32);
+}
+
+// Modular subtraction: (p - a) mod p
++ (void)bigSubFromP:(const uint8_t *)a p:(const uint8_t *)p result:(uint8_t *)result {
+    int16_t borrow = 0;
+    for (int i = 31; i >= 0; i--) {
+        int16_t diff = (int16_t)p[i] - (int16_t)a[i] - borrow;
+        if (diff < 0) {
+            diff += 256;
+            borrow = 1;
+        } else {
+            borrow = 0;
+        }
+        result[i] = (uint8_t)diff;
+    }
+}
+
++ (NSData * _Nullable)computeYFromX:(NSData *)xData yOdd:(BOOL)yOdd {
+    const uint8_t *x = xData.bytes;
+    const uint8_t *p = secp256r1_p;
+    const uint8_t *a = secp256r1_a;
+    const uint8_t *b = secp256r1_b;
+
+    // Compute y^2 = x^3 + a*x + b (mod p)
+    // Step 1: x^2 mod p
+    uint8_t x2[32];
+    [self bigMulMod:x b:x p:p result:x2];
+
+    // Step 2: x^3 mod p
+    uint8_t x3[32];
+    [self bigMulMod:x2 b:x p:p result:x3];
+
+    // Step 3: a*x mod p
+    uint8_t ax[32];
+    [self bigMulMod:a b:x p:p result:ax];
+
+    // Step 4: x^3 + a*x mod p
+    uint8_t sum1[32];
+    [self bigAddMod:x3 b:ax p:p result:sum1];
+
+    // Step 5: x^3 + a*x + b mod p
+    uint8_t ySquared[32];
+    [self bigAddMod:sum1 b:b p:p result:ySquared];
+
+    // Step 6: y = ySquared^((p+1)/4) mod p (since p ≡ 3 mod 4)
+    uint8_t y[32];
+    [self bigModPow:ySquared exp:secp256r1_p_plus1_div4 p:p result:y];
+
+    // Check parity
+    BOOL yIsOdd = (y[31] & 1) != 0;
+    if (yIsOdd != yOdd) {
+        uint8_t negY[32];
+        [self bigSubFromP:y p:p result:negY];
+        return [NSData dataWithBytes:negY length:32];
+    }
+
+    return [NSData dataWithBytes:y length:32];
+}
+
+#pragma mark - SecKey Operations
+
++ (SecKeyRef _Nullable)createECPublicKeyFromUncompressedData:(NSData *)uncompressedData {
+    // The Security framework on iOS expects the key data to include the 0x04 prefix
+    // for uncompressed EC points when using kSecAttrKeyTypeECSECPrimeRandom
+    NSDictionary *attributes = @{
+        (id)kSecAttrKeyType: (id)kSecAttrKeyTypeECSECPrimeRandom,
+        (id)kSecAttrKeyClass: (id)kSecAttrKeyClassPublic,
+        (id)kSecAttrKeySizeInBits: @256,
+    };
+
+    CFErrorRef error = NULL;
+    SecKeyRef key = SecKeyCreateWithData((__bridge CFDataRef)uncompressedData,
+                                          (__bridge CFDictionaryRef)attributes,
+                                          &error);
+    if (error != NULL) {
+        CFRelease(error);
+        return NULL;
+    }
+    return key;
+}
+
++ (BOOL)generateEphemeralKeyPairPrivate:(SecKeyRef *)privateKey public:(SecKeyRef *)publicKey {
+    NSDictionary *attributes = @{
+        (id)kSecAttrKeyType: (id)kSecAttrKeyTypeECSECPrimeRandom,
+        (id)kSecAttrKeySizeInBits: @256,
+    };
+
+    CFErrorRef error = NULL;
+    *privateKey = SecKeyCreateRandomKey((__bridge CFDictionaryRef)attributes, &error);
+    if (*privateKey == NULL) {
+        if (error != NULL) CFRelease(error);
+        return NO;
+    }
+
+    *publicKey = SecKeyCopyPublicKey(*privateKey);
+    if (*publicKey == NULL) {
+        CFRelease(*privateKey);
+        *privateKey = NULL;
+        return NO;
+    }
+
+    return YES;
+}
+
++ (NSData * _Nullable)computeECDHSharedSecret:(SecKeyRef)privateKey withPublicKey:(SecKeyRef)publicKey {
+    NSDictionary *params = @{};
+    CFErrorRef error = NULL;
+    CFDataRef sharedSecretRef = SecKeyCopyKeyExchangeResult(privateKey,
+                                                             kSecKeyAlgorithmECDHKeyExchangeStandard,
+                                                             publicKey,
+                                                             (__bridge CFDictionaryRef)params,
+                                                             &error);
+    if (sharedSecretRef == NULL) {
+        if (error != NULL) CFRelease(error);
+        return nil;
+    }
+
+    NSData *sharedSecret = (__bridge_transfer NSData *)sharedSecretRef;
+    return sharedSecret;
+}
+
++ (NSData *)sha256:(NSData *)data {
+    uint8_t hash[CC_SHA256_DIGEST_LENGTH];
+    CC_SHA256(data.bytes, (CC_LONG)data.length, hash);
+    return [NSData dataWithBytes:hash length:CC_SHA256_DIGEST_LENGTH];
+}
+
++ (NSData * _Nullable)exportUncompressedPublicKey:(SecKeyRef)publicKey {
+    CFErrorRef error = NULL;
+    CFDataRef keyData = SecKeyCopyExternalRepresentation(publicKey, &error);
+    if (keyData == NULL) {
+        if (error != NULL) CFRelease(error);
+        return nil;
+    }
+
+    NSData *data = (__bridge_transfer NSData *)keyData;
+
+    // On iOS, the external representation of an EC public key is the
+    // uncompressed point: 0x04 + X(32) + Y(32) = 65 bytes
+    if (data.length == kUncompressedKeyLength) {
+        return data;
+    }
+
+    return nil;
+}
+
+#pragma mark - AES-256-GCM
+
++ (BOOL)aesGcmEncrypt:(NSData *)plaintext
+                   key:(NSData *)key
+                    iv:(NSData *)iv
+            ciphertext:(NSMutableData *)ciphertext
+               authTag:(NSMutableData *)authTag {
+    // Use step-by-step CCCryptorGCM API for broad iOS compatibility
+    CCCryptorRef cryptorRef = NULL;
+    CCCryptorStatus status;
+
+    status = CCCryptorCreateWithMode(kCCEncrypt,
+                                      11, // kCCModeGCM = 11
+                                      kCCAlgorithmAES,
+                                      ccNoPadding,
+                                      NULL, // iv set separately for GCM
+                                      key.bytes,
+                                      key.length,
+                                      NULL, 0, 0, 0,
+                                      &cryptorRef);
+    if (status != kCCSuccess || cryptorRef == NULL) {
+        return NO;
+    }
+
+    // Set IV using CCCryptorGCMSetIV
+    status = CCCryptorGCMSetIV(cryptorRef, iv.bytes, iv.length);
+    if (status != kCCSuccess) {
+        CCCryptorRelease(cryptorRef);
+        return NO;
+    }
+
+    // Encrypt
+    status = CCCryptorGCMEncrypt(cryptorRef, plaintext.bytes, plaintext.length, ciphertext.mutableBytes);
+    if (status != kCCSuccess) {
+        CCCryptorRelease(cryptorRef);
+        return NO;
+    }
+
+    // Finalize and get auth tag
+    size_t tagLength = kAuthTagLength;
+    status = CCCryptorGCMFinalize(cryptorRef, authTag.mutableBytes, tagLength);
+    CCCryptorRelease(cryptorRef);
+
+    return status == kCCSuccess;
+}
+
+@end

--- a/AvoInspector/Classes/AvoInspector.h
+++ b/AvoInspector/Classes/AvoInspector.h
@@ -29,6 +29,13 @@ typedef NS_ENUM(NSUInteger, AvoInspectorEnv) {
 
 -(instancetype) initWithApiKey: (NSString *) apiKey env: (AvoInspectorEnv) env proxyEndpoint: (NSString *) proxyEndpoint;
 
+-(instancetype) initWithApiKey: (NSString *) apiKey env: (AvoInspectorEnv) env
+          publicEncryptionKey: (NSString * _Nullable) publicEncryptionKey;
+
+-(instancetype) initWithApiKey: (NSString *) apiKey env: (AvoInspectorEnv) env
+                proxyEndpoint: (NSString *) proxyEndpoint
+          publicEncryptionKey: (NSString * _Nullable) publicEncryptionKey;
+
 + (id<AvoStorage>)avoStorage;
 
 @end

--- a/AvoInspector/Classes/AvoInspector.m
+++ b/AvoInspector/Classes/AvoInspector.m
@@ -49,6 +49,7 @@
 @property (readwrite, nonatomic, nullable) AvoEventSpecFetcher *eventSpecFetcher;
 @property (readwrite, nonatomic, nullable) AvoEventSpecCache *eventSpecCache;
 @property (readwrite, nonatomic, nullable) NSString *currentBranchId;
+@property (readwrite, nonatomic, nullable) NSString *publicEncryptionKey;
 
 @end
 
@@ -103,6 +104,14 @@ static const NSTimeInterval EVENT_SPEC_FETCH_TIMEOUT = 5.0;
 }
 
 -(instancetype) initWithApiKey: (NSString *) apiKey env: (AvoInspectorEnv) env proxyEndpoint: (NSString *) proxyEndpoint {
+    return [self initWithApiKey:apiKey env:env proxyEndpoint:proxyEndpoint publicEncryptionKey:nil];
+}
+
+-(instancetype) initWithApiKey: (NSString *) apiKey env: (AvoInspectorEnv) env publicEncryptionKey: (NSString * _Nullable) publicEncryptionKey {
+    return [self initWithApiKey:apiKey env:env proxyEndpoint:@"https://api.avo.app/inspector/v1/track" publicEncryptionKey:publicEncryptionKey];
+}
+
+-(instancetype) initWithApiKey: (NSString *) apiKey env: (AvoInspectorEnv) env proxyEndpoint: (NSString *) proxyEndpoint publicEncryptionKey: (NSString * _Nullable) publicEncryptionKey {
     self = [super init];
     if (self) {
         if (env != AvoInspectorEnvProd && env != AvoInspectorEnvDev && env != AvoInspectorEnvStaging) {
@@ -111,6 +120,7 @@ static const NSTimeInterval EVENT_SPEC_FETCH_TIMEOUT = 5.0;
             self.env = env;
         }
 
+        self.publicEncryptionKey = publicEncryptionKey;
         self.avoSchemaExtractor = [AvoSchemaExtractor new];
 
         if (env == AvoInspectorEnvDev) {
@@ -133,12 +143,18 @@ static const NSTimeInterval EVENT_SPEC_FETCH_TIMEOUT = 5.0;
 
         self.notificationCenter = [NSNotificationCenter defaultCenter];
 
-        self.networkCallsHandler = [[AvoNetworkCallsHandler alloc] initWithApiKey:apiKey appName:self.appName appVersion:self.appVersion libVersion:self.libVersion env:(int)self.env endpoint: proxyEndpoint];
+        self.networkCallsHandler = [[AvoNetworkCallsHandler alloc] initWithApiKey:apiKey appName:self.appName appVersion:self.appVersion libVersion:self.libVersion env:(int)self.env endpoint:proxyEndpoint publicEncryptionKey:publicEncryptionKey];
         self.avoBatcher = [[AvoBatcher alloc] initWithNetworkCallsHandler:self.networkCallsHandler];
 
         self.avoDeduplicator = [AvoDeduplicator sharedDeduplicator];
 
         self.apiKey = apiKey;
+
+        if (publicEncryptionKey != nil && publicEncryptionKey.length > 0 && env != AvoInspectorEnvProd) {
+            if ([AvoInspector isLogging]) {
+                NSLog(@"[avo] Avo Inspector: Property value encryption enabled");
+            }
+        }
 
         // Initialize event spec fetcher and cache for non-prod environments
         // streamId is the anonymous ID, obtained internally from AvoAnonymousId
@@ -163,7 +179,7 @@ static const NSTimeInterval EVENT_SPEC_FETCH_TIMEOUT = 5.0;
 }
 
 -(instancetype) initWithApiKey: (NSString *) apiKey env: (AvoInspectorEnv) env {
-    self = [self initWithApiKey:apiKey env:env proxyEndpoint:@"https://api.avo.app/inspector/v1/track"];
+    self = [self initWithApiKey:apiKey env:env proxyEndpoint:@"https://api.avo.app/inspector/v1/track" publicEncryptionKey:nil];
     return self;
 }
 
@@ -255,7 +271,7 @@ static const NSTimeInterval EVENT_SPEC_FETCH_TIMEOUT = 5.0;
 
         NSDictionary * schema = [self.avoSchemaExtractor extractSchema:params];
 
-        [self fetchAndValidateAsync:eventName eventParams:params eventSchema:schema eventId:eventId eventHash:eventHash];
+        [self fetchAndValidateAsync:eventName eventParams:params eventSchema:schema eventId:eventId eventHash:eventHash eventProperties:params];
 
         return schema;
     }
@@ -269,7 +285,7 @@ static const NSTimeInterval EVENT_SPEC_FETCH_TIMEOUT = 5.0;
 -(void) trackSchema:(NSString *) eventName eventSchema:(NSDictionary<NSString *, AvoEventSchemaType *> *) schema {
     @try {
         if ([self.avoDeduplicator shouldRegisterSchemaFromManually:eventName schema:schema]) {
-            [self internalTrackSchema:eventName eventSchema:schema eventId:nil eventHash:nil];
+            [self internalTrackSchema:eventName eventSchema:schema eventId:nil eventHash:nil eventProperties:nil];
         } else {
             if ([AvoInspector isLogging]) {
                 NSLog(@"[avo] Avo Inspector: Deduplicated schema %@", eventName);
@@ -281,7 +297,7 @@ static const NSTimeInterval EVENT_SPEC_FETCH_TIMEOUT = 5.0;
     }
 }
 
--(void) internalTrackSchema:(NSString *) eventName eventSchema:(NSDictionary<NSString *, AvoEventSchemaType *> *) schema eventId:(NSString *) eventId eventHash:(NSString *) eventHash {
+-(void) internalTrackSchema:(NSString *) eventName eventSchema:(NSDictionary<NSString *, AvoEventSchemaType *> *) schema eventId:(NSString *) eventId eventHash:(NSString *) eventHash eventProperties:(NSDictionary * _Nullable) eventProperties {
 
     @try {
         for(NSString *key in [schema allKeys]) {
@@ -290,7 +306,11 @@ static const NSTimeInterval EVENT_SPEC_FETCH_TIMEOUT = 5.0;
             }
         }
 
-        [self.avoBatcher handleTrackSchema:eventName schema:schema eventId: eventId eventHash:eventHash];
+        if (eventProperties != nil && eventProperties.count > 0) {
+            [self.avoBatcher handleTrackSchema:eventName schema:schema eventId:eventId eventHash:eventHash eventProperties:eventProperties];
+        } else {
+            [self.avoBatcher handleTrackSchema:eventName schema:schema eventId:eventId eventHash:eventHash];
+        }
     }
     @catch (NSException *exception) {
         [self.avoSchemaExtractor printAvoParsingError:exception];
@@ -307,12 +327,12 @@ static const NSTimeInterval EVENT_SPEC_FETCH_TIMEOUT = 5.0;
 
 #pragma mark - Event Spec Fetch & Validate
 
--(void)fetchAndValidateAsync:(NSString *)eventName eventParams:(NSDictionary<NSString *, id> *)params eventSchema:(NSDictionary<NSString *, AvoEventSchemaType *> *)schema eventId:(NSString *)eventId eventHash:(NSString *)eventHash {
+-(void)fetchAndValidateAsync:(NSString *)eventName eventParams:(NSDictionary<NSString *, id> *)params eventSchema:(NSDictionary<NSString *, AvoEventSchemaType *> *)schema eventId:(NSString *)eventId eventHash:(NSString *)eventHash eventProperties:(NSDictionary * _Nullable) eventProperties {
 
     // If no fetcher (prod, etc.), fall through to existing path
     NSString *streamId = [AvoAnonymousId anonymousId];
     if (self.eventSpecFetcher == nil || self.eventSpecCache == nil || streamId == nil || [streamId isEqualToString:@"unknown"] || params == nil || params.count == 0) {
-        [self internalTrackSchema:eventName eventSchema:schema eventId:eventId eventHash:eventHash];
+        [self internalTrackSchema:eventName eventSchema:schema eventId:eventId eventHash:eventHash eventProperties:eventProperties];
         return;
     }
 
@@ -324,12 +344,12 @@ static const NSTimeInterval EVENT_SPEC_FETCH_TIMEOUT = 5.0;
         if (cachedSpec != nil) {
             AvoValidationResult *validationResult = [AvoEventValidator validateEvent:params specResponse:cachedSpec];
             if (validationResult != nil) {
-                [self sendEventWithValidation:eventName schema:schema eventId:eventId eventHash:eventHash validationResult:validationResult];
+                [self sendEventWithValidation:eventName schema:schema eventId:eventId eventHash:eventHash validationResult:validationResult eventProperties:eventProperties];
                 return;
             }
         }
         // Cache hit but nil spec or no validation result - use existing path
-        [self internalTrackSchema:eventName eventSchema:schema eventId:eventId eventHash:eventHash];
+        [self internalTrackSchema:eventName eventSchema:schema eventId:eventId eventHash:eventHash eventProperties:eventProperties];
         return;
     }
 
@@ -358,10 +378,10 @@ static const NSTimeInterval EVENT_SPEC_FETCH_TIMEOUT = 5.0;
             // Validate and send the validated event
             AvoValidationResult *validationResult = [AvoEventValidator validateEvent:capturedParams specResponse:specResponse];
             if (validationResult != nil) {
-                [strongSelf sendEventWithValidation:eventName schema:schema eventId:eventId eventHash:eventHash validationResult:validationResult];
+                [strongSelf sendEventWithValidation:eventName schema:schema eventId:eventId eventHash:eventHash validationResult:validationResult eventProperties:eventProperties];
             } else {
                 // Validation returned nil — send through batched path
-                [strongSelf internalTrackSchema:eventName eventSchema:schema eventId:eventId eventHash:eventHash];
+                [strongSelf internalTrackSchema:eventName eventSchema:schema eventId:eventId eventHash:eventHash eventProperties:eventProperties];
             }
         } else {
             // Cache nil to avoid re-fetching within TTL, send through batched path
@@ -369,7 +389,7 @@ static const NSTimeInterval EVENT_SPEC_FETCH_TIMEOUT = 5.0;
             if ([AvoInspector isLogging]) {
                 NSLog(@"[avo] Avo Inspector: Event spec fetch returned nil for event: %@. Cached empty response. Sending without validation.", eventName);
             }
-            [strongSelf internalTrackSchema:eventName eventSchema:schema eventId:eventId eventHash:eventHash];
+            [strongSelf internalTrackSchema:eventName eventSchema:schema eventId:eventId eventHash:eventHash eventProperties:eventProperties];
         }
     }];
 }
@@ -388,10 +408,10 @@ static const NSTimeInterval EVENT_SPEC_FETCH_TIMEOUT = 5.0;
     [self.eventSpecCache set:cacheKey spec:specResponse];
 }
 
--(void)sendEventWithValidation:(NSString *)eventName schema:(NSDictionary<NSString *, AvoEventSchemaType *> *)schema eventId:(NSString *)eventId eventHash:(NSString *)eventHash validationResult:(AvoValidationResult *)validationResult {
+-(void)sendEventWithValidation:(NSString *)eventName schema:(NSDictionary<NSString *, AvoEventSchemaType *> *)schema eventId:(NSString *)eventId eventHash:(NSString *)eventHash validationResult:(AvoValidationResult *)validationResult eventProperties:(NSDictionary * _Nullable) eventProperties {
     @try {
         NSString *streamId = [AvoAnonymousId anonymousId];
-        NSMutableDictionary *body = [self.networkCallsHandler bodyForValidatedEventSchemaCall:eventName schema:schema eventId:eventId eventHash:eventHash validationResult:validationResult streamId:streamId];
+        NSMutableDictionary *body = [self.networkCallsHandler bodyForValidatedEventSchemaCall:eventName schema:schema eventId:eventId eventHash:eventHash validationResult:validationResult streamId:streamId eventProperties:eventProperties];
 
         if ([AvoInspector isLogging]) {
             NSLog(@"[avo] Avo Inspector: Sending validated event %@", eventName);

--- a/AvoInspector/Classes/AvoNetworkCallsHandler.h
+++ b/AvoInspector/Classes/AvoNetworkCallsHandler.h
@@ -22,11 +22,21 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype) initWithApiKey: (NSString *) apiKey appName: (NSString *)appName appVersion: (NSString *) appVersion libVersion: (NSString *) libVersion env: (int) env endpoint: (NSString *) endpoint;
 
+- (instancetype) initWithApiKey: (NSString *) apiKey appName: (NSString *)appName appVersion: (NSString *) appVersion libVersion: (NSString *) libVersion env: (int) env endpoint: (NSString *) endpoint publicEncryptionKey: (NSString * _Nullable) publicEncryptionKey;
+
 - (void) callInspectorWithBatchBody: (NSArray *) batchBody completionHandler:(void (^)(NSError *error))completionHandler;
 
 - (NSMutableDictionary *) bodyForTrackSchemaCall:(NSString *) eventName schema:(NSDictionary *) schema eventId:(NSString * _Nullable) eventId eventHash:(NSString * _Nullable) eventHash;
 
+- (NSMutableDictionary *) bodyForTrackSchemaCall:(NSString *) eventName schema:(NSDictionary *) schema eventId:(NSString * _Nullable) eventId eventHash:(NSString * _Nullable) eventHash eventProperties:(NSDictionary * _Nullable) eventProperties;
+
 - (NSMutableDictionary *) bodyForValidatedEventSchemaCall:(NSString *) eventName schema:(NSDictionary<NSString *, AvoEventSchemaType *> *) schema eventId:(NSString * _Nullable) eventId eventHash:(NSString * _Nullable) eventHash validationResult:(AvoValidationResult *) validationResult streamId:(NSString *) streamId;
+
+- (NSMutableDictionary *) bodyForValidatedEventSchemaCall:(NSString *) eventName schema:(NSDictionary<NSString *, AvoEventSchemaType *> *) schema eventId:(NSString * _Nullable) eventId eventHash:(NSString * _Nullable) eventHash validationResult:(AvoValidationResult *) validationResult streamId:(NSString *) streamId eventProperties:(NSDictionary * _Nullable) eventProperties;
+
+- (BOOL) shouldEncrypt;
+
++ (NSString * _Nullable) jsonStringifyValue:(id) value;
 
 - (void) reportValidatedEvent:(NSDictionary *) body;
 

--- a/AvoInspector/Classes/AvoNetworkCallsHandler.m
+++ b/AvoInspector/Classes/AvoNetworkCallsHandler.m
@@ -11,6 +11,8 @@
 #import "AvoObject.h"
 #import "AvoAnonymousId.h"
 #import "AvoEventSpecFetchTypes.h"
+#import "AvoEncryption.h"
+#import "AvoList.h"
 
 @interface AvoNetworkCallsHandler()
 
@@ -21,6 +23,7 @@
 @property (readwrite, nonatomic) NSString *libVersion;
 @property (readwrite, nonatomic) NSURLSession *urlSession;
 @property (readwrite, nonatomic) NSString *endpoint;
+@property (readwrite, nonatomic, nullable) NSString *publicEncryptionKey;
 
 @property (readwrite, nonatomic) double samplingRate;
 
@@ -29,6 +32,10 @@
 @implementation AvoNetworkCallsHandler
 
 - (instancetype) initWithApiKey: (NSString *) apiKey appName: (NSString *)appName appVersion: (NSString *) appVersion libVersion: (NSString *) libVersion env: (int) env endpoint: (NSString *) endpoint {
+    return [self initWithApiKey:apiKey appName:appName appVersion:appVersion libVersion:libVersion env:env endpoint:endpoint publicEncryptionKey:nil];
+}
+
+- (instancetype) initWithApiKey: (NSString *) apiKey appName: (NSString *)appName appVersion: (NSString *) appVersion libVersion: (NSString *) libVersion env: (int) env endpoint: (NSString *) endpoint publicEncryptionKey: (NSString * _Nullable) publicEncryptionKey {
     self = [super init];
     if (self) {
         self.endpoint = endpoint;
@@ -39,18 +46,23 @@
         self.samplingRate = 1.0;
         self.env = env;
         self.urlSession = [NSURLSession sharedSession];
+        self.publicEncryptionKey = publicEncryptionKey;
     }
     return self;
 }
 
 - (NSMutableDictionary *) bodyForTrackSchemaCall:(NSString *) eventName schema:(NSDictionary<NSString *, AvoEventSchemaType *> *) schema eventId:(NSString * _Nullable) eventId eventHash:(NSString * _Nullable) eventHash {
+    return [self bodyForTrackSchemaCall:eventName schema:schema eventId:eventId eventHash:eventHash eventProperties:nil];
+}
+
+- (NSMutableDictionary *) bodyForTrackSchemaCall:(NSString *) eventName schema:(NSDictionary<NSString *, AvoEventSchemaType *> *) schema eventId:(NSString * _Nullable) eventId eventHash:(NSString * _Nullable) eventHash eventProperties:(NSDictionary * _Nullable) eventProperties {
     NSMutableArray * propsSchema = [NSMutableArray new];
-    
+
     for(NSString *key in [schema allKeys]) {
         NSString *value = [[schema objectForKey:key] name];
-        
+
         NSMutableDictionary *prop = [NSMutableDictionary new];
-        
+
         [prop setObject:key forKey:@"propertyName"];
         if ([[schema objectForKey:key] isKindOfClass:[AvoObject class]]) {
             NSError *error = nil;
@@ -60,9 +72,9 @@
                               error:&error];
             if (!error && [nestedSchema isKindOfClass:[NSDictionary class]]) {
                 NSDictionary *results = nestedSchema;
-                
+
                 [prop setObject:@"object" forKey:@"propertyType"];
-                
+
                 [prop setObject:[self bodyFromJson:results] forKey:@"children"];
             }
         } else {
@@ -70,9 +82,13 @@
         }
         [propsSchema addObject:prop];
     }
-    
+
+    if ([self shouldEncrypt] && eventProperties != nil) {
+        [AvoNetworkCallsHandler addEncryptedValues:propsSchema eventProperties:eventProperties publicEncryptionKey:self.publicEncryptionKey];
+    }
+
     NSMutableDictionary * baseBody = [self createBaseCallBody];
-    
+
     if (eventId != nil) {
         [baseBody setValue:@YES forKey:@"avoFunction"];
         [baseBody setValue:eventId forKey:@"eventId"];
@@ -80,11 +96,11 @@
     } else {
         [baseBody setValue:@NO forKey:@"avoFunction"];
     }
-    
+
     [baseBody setValue:@"event" forKey:@"type"];
     [baseBody setValue:eventName forKey:@"eventName"];
     [baseBody setValue:propsSchema forKey:@"eventProperties"];
-    
+
     return baseBody;
 }
 
@@ -127,6 +143,10 @@
     [body setValue:@"ios" forKey:@"libPlatform"];
     [body setValue:[[NSUUID UUID] UUIDString] forKey:@"messageId"];
     [body setValue:[AvoUtils currentTimeAsISO8601UTCString] forKey:@"createdAt"];
+
+    if (self.publicEncryptionKey != nil && self.publicEncryptionKey.length > 0) {
+        [body setValue:self.publicEncryptionKey forKey:@"publicEncryptionKey"];
+    }
 
     return body;
 }
@@ -207,6 +227,10 @@
 }
 
 - (NSMutableDictionary *) bodyForValidatedEventSchemaCall:(NSString *) eventName schema:(NSDictionary<NSString *, AvoEventSchemaType *> *) schema eventId:(NSString * _Nullable) eventId eventHash:(NSString * _Nullable) eventHash validationResult:(AvoValidationResult *) validationResult streamId:(NSString *) streamId {
+    return [self bodyForValidatedEventSchemaCall:eventName schema:schema eventId:eventId eventHash:eventHash validationResult:validationResult streamId:streamId eventProperties:nil];
+}
+
+- (NSMutableDictionary *) bodyForValidatedEventSchemaCall:(NSString *) eventName schema:(NSDictionary<NSString *, AvoEventSchemaType *> *) schema eventId:(NSString * _Nullable) eventId eventHash:(NSString * _Nullable) eventHash validationResult:(AvoValidationResult *) validationResult streamId:(NSString *) streamId eventProperties:(NSDictionary * _Nullable) eventProperties {
 
     NSMutableArray *propsSchema = [NSMutableArray new];
 
@@ -239,6 +263,10 @@
         }
 
         [propsSchema addObject:prop];
+    }
+
+    if ([self shouldEncrypt] && eventProperties != nil) {
+        [AvoNetworkCallsHandler addEncryptedValues:propsSchema eventProperties:eventProperties publicEncryptionKey:self.publicEncryptionKey];
     }
 
     NSMutableDictionary *baseBody = [self createBaseCallBody];
@@ -356,6 +384,72 @@
     }
 
     return result;
+}
+
+#pragma mark - Encryption
+
+- (BOOL) shouldEncrypt {
+    return self.publicEncryptionKey != nil
+        && self.publicEncryptionKey.length > 0
+        && (self.env == 1 || self.env == 2); // dev = 1, staging = 2
+}
+
++ (void) addEncryptedValues:(NSMutableArray *)properties eventProperties:(NSDictionary *)eventProperties publicEncryptionKey:(NSString *)publicEncryptionKey {
+    if (properties == nil || eventProperties == nil || publicEncryptionKey == nil) {
+        return;
+    }
+
+    for (NSUInteger i = 0; i < properties.count; i++) {
+        @try {
+            NSMutableDictionary *prop = properties[i];
+            NSString *propertyName = prop[@"propertyName"];
+            NSString *propertyType = prop[@"propertyType"];
+            id value = eventProperties[propertyName];
+
+            if (value == nil) {
+                continue;
+            }
+
+            if ([propertyType isEqualToString:@"object"] && prop[@"children"] != nil && [value isKindOfClass:[NSDictionary class]]) {
+                // Recurse into object children
+                NSMutableArray *children = prop[@"children"];
+                [self addEncryptedValues:children eventProperties:(NSDictionary *)value publicEncryptionKey:publicEncryptionKey];
+            } else if (![propertyType hasPrefix:@"list"]) {
+                // Primitive type: encrypt the JSON-stringified value
+                NSString *jsonValue = [self jsonStringifyValue:value];
+                if (jsonValue != nil) {
+                    NSString *encrypted = [AvoEncryption encrypt:jsonValue recipientPublicKeyHex:publicEncryptionKey];
+                    if (encrypted != nil) {
+                        prop[@"encryptedPropertyValue"] = encrypted;
+                    }
+                }
+            }
+            // list types are skipped
+        } @catch (NSException *e) {
+            if ([AvoInspector isLogging]) {
+                NSLog(@"[avo] Avo Inspector: Failed to encrypt property at index %lu: %@", (unsigned long)i, e);
+            }
+        }
+    }
+}
+
++ (NSString * _Nullable) jsonStringifyValue:(id) value {
+    @try {
+        // Wrap value in an array to get proper JSON representation
+        NSArray *wrapper = @[value];
+        NSData *jsonData = [NSJSONSerialization dataWithJSONObject:wrapper options:0 error:nil];
+        if (jsonData == nil) {
+            return nil;
+        }
+        NSString *json = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+        if (json == nil || json.length < 2) {
+            return nil;
+        }
+        // Strip surrounding brackets: [value] -> value
+        return [json substringWithRange:NSMakeRange(1, json.length - 2)];
+    } @catch (NSException *e) {
+        return nil;
+    }
 }
 
 @end

--- a/Example/AvoStateOfTracking.xcodeproj/project.pbxproj
+++ b/Example/AvoStateOfTracking.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		000F4B6B77DB28A21F58A99E /* Pods_AvoStateOfTracking_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 477A7DB1E300D6CCCB497073 /* Pods_AvoStateOfTracking_Example.framework */; };
+		1BFBEEE38BE0FE929AF8B956 /* AvoEncryptionIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 93E26A5F901066963861F636 /* AvoEncryptionIntegrationTests.m */; };
+		2D3C54CD8AB3824C81547AA6 /* AvoEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 116077C7B279A33311E05AEF /* AvoEncryptionTests.m */; };
 		301AB520EE651FAEF0985BF7 /* AvoEventSpecCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 58BBA119ADBF687E498F0256 /* AvoEventSpecCacheTests.m */; };
 		58750A8C25B41A11A5226238 /* AvoEventValidatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E9A0A3986F479ECA7F6844E4 /* AvoEventValidatorTests.m */; };
 		6003F58E195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
@@ -51,6 +53,7 @@
 
 /* Begin PBXFileReference section */
 		0385A7D967CD2A317A48054A /* Pods_AvoStateOfTracking_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AvoStateOfTracking_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		116077C7B279A33311E05AEF /* AvoEncryptionTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = AvoEncryptionTests.m; sourceTree = "<group>"; };
 		18EDCD8FB8CCED3A1897C0A4 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		477A7DB1E300D6CCCB497073 /* Pods_AvoStateOfTracking_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AvoStateOfTracking_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		58BBA119ADBF687E498F0256 /* AvoEventSpecCacheTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = AvoEventSpecCacheTests.m; sourceTree = "<group>"; };
@@ -87,6 +90,7 @@
 		71719F9E1E33DC2100824A3D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		873B8AEA1B1F5CCA007FD442 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = Main.storyboard; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		87E70B6034DD8F288503AB25 /* Pods-AvoStateOfTracking_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AvoStateOfTracking_Example.release.xcconfig"; path = "Target Support Files/Pods-AvoStateOfTracking_Example/Pods-AvoStateOfTracking_Example.release.xcconfig"; sourceTree = "<group>"; };
+		93E26A5F901066963861F636 /* AvoEncryptionIntegrationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = AvoEncryptionIntegrationTests.m; sourceTree = "<group>"; };
 		B28235AFC6E48D36D0E38644 /* AvoInspector.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = AvoInspector.podspec; path = ../AvoInspector.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		B98C773A43DE3E8F6C478C85 /* Pods-AvoStateOfTracking_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AvoStateOfTracking_Tests.release.xcconfig"; path = "Target Support Files/Pods-AvoStateOfTracking_Tests/Pods-AvoStateOfTracking_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		BEB89237300F3787D57D1AAA /* Pods-AvoStateOfTracking_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AvoStateOfTracking_Tests.debug.xcconfig"; path = "Target Support Files/Pods-AvoStateOfTracking_Tests/Pods-AvoStateOfTracking_Tests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -200,6 +204,8 @@
 				58BBA119ADBF687E498F0256 /* AvoEventSpecCacheTests.m */,
 				E9A0A3986F479ECA7F6844E4 /* AvoEventValidatorTests.m */,
 				67B497389F519CACB0D85717 /* AvoEventSpecFetcherTests.m */,
+				116077C7B279A33311E05AEF /* AvoEncryptionTests.m */,
+				93E26A5F901066963861F636 /* AvoEncryptionIntegrationTests.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -459,6 +465,8 @@
 				301AB520EE651FAEF0985BF7 /* AvoEventSpecCacheTests.m in Sources */,
 				58750A8C25B41A11A5226238 /* AvoEventValidatorTests.m in Sources */,
 				BAD0466DD8B620F27723BBB6 /* AvoEventSpecFetcherTests.m in Sources */,
+				2D3C54CD8AB3824C81547AA6 /* AvoEncryptionTests.m in Sources */,
+				1BFBEEE38BE0FE929AF8B956 /* AvoEncryptionIntegrationTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/AvoStateOfTracking/AVOAppDelegate.m
+++ b/Example/AvoStateOfTracking/AVOAppDelegate.m
@@ -8,6 +8,15 @@
 
 #import "AVOAppDelegate.h"
 
+// Local API key override (gitignored). Falls back to default if not present.
+#if __has_include("LocalConfig.h")
+#import "LocalConfig.h"
+#endif
+
+#ifndef AVO_INSPECTOR_API_KEY
+#define AVO_INSPECTOR_API_KEY @"A4lTbBQTGVyD1f66213X"
+#endif
+
 @implementation AVOAppDelegate
 
 AvoInspector * avoInspector;
@@ -15,8 +24,8 @@ AvoInspector * avoInspector;
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
     // Override point for customization after application launch.
-    avoInspector = [[AvoInspector alloc] initWithApiKey:@"A4lTbBQTGVyD1f66213X" env: AvoInspectorEnvDev];
-    
+    avoInspector = [[AvoInspector alloc] initWithApiKey:AVO_INSPECTOR_API_KEY env: AvoInspectorEnvDev publicEncryptionKey: @"024ec9c17ea2fb3e727d2815941eeb7d7c6e551536c9e2dde37fbbf0ffb9850579"]; // example key, decrypt with 2f6f681eb9b9ce4d72c40fc3c860e1b484fc9001ceb8de162c0086c1c8c619cf
+
     return YES;
 }
 

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,277 +7,280 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0074EDFA6F113371C756BEC02C8754D3 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6FD9D030738482969FA185B5402D2F8D /* Foundation.framework */; };
+		0083550F521381651B3DA6C7ADC2FB7E /* FBSnapshotTestController.h in Headers */ = {isa = PBXBuildFile; fileRef = 52B484650A9CAD7F15D3D8CC26049E1C /* FBSnapshotTestController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		016E585A9773A577C64A433B8DB6E19E /* Specta-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = EC9C902129ADABE5DEF960D3A70EA3E4 /* Specta-dummy.m */; };
 		0199465BD4BD1E68FB35F8D1AE172C24 /* OCMInvocationStub.m in Sources */ = {isa = PBXBuildFile; fileRef = 788AE818ADA9C260023A98F83BADD6A9 /* OCMInvocationStub.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		01C229CAFF9272677D1ACC7AD06C583C /* XCTestCase+Specta.m in Sources */ = {isa = PBXBuildFile; fileRef = 0791ADF7811A716A85EDDAE31FD5D0D7 /* XCTestCase+Specta.m */; };
 		023A02F7D7C4EA0DCB7EB872789EB273 /* NSData+SEGGZIP.m in Sources */ = {isa = PBXBuildFile; fileRef = 06B74191208497A94209986C8C252EB0 /* NSData+SEGGZIP.m */; };
-		0289329B60AFF8EBB8B5A432EFC4978D /* SPTCallSite.m in Sources */ = {isa = PBXBuildFile; fileRef = 9223479EA77FBA1BD66D805B46ADB563 /* SPTCallSite.m */; };
-		032B3FA68D7AD53A3EE6F2459A0EB0DA /* AvoString.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E874ECE0A24B5C627147DA932F29C1F /* AvoString.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		044B1562D28200AE1ADF52860F50581A /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 699C91B5CB2674B514629B0861E1D11A /* PrivacyInfo.xcprivacy */; };
+		02419169E760275280A83FF8C65C6612 /* AvoList.m in Sources */ = {isa = PBXBuildFile; fileRef = 929B9AA67483862EEB4B5FA238D2DB15 /* AvoList.m */; };
+		02ACB111A19FB060759FAB180179BF6C /* AvoUnknownType.m in Sources */ = {isa = PBXBuildFile; fileRef = 85A7ABFC918C7DAED63625F2BD0B12DA /* AvoUnknownType.m */; };
 		06071B62F6A6EBBDB113899064823027 /* OCMNonRetainingObjectReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 2AAC25E011D77CB3D4BB4BF082EA87C7 /* OCMNonRetainingObjectReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		061ABEFF2D70080A499919F67E9A9886 /* NSNotificationCenter+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = E25F299BBCF8EDB133A39FF6B8A2C667 /* NSNotificationCenter+OCMAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		06A850BE3B9CFF54086BCC6121173F25 /* EXPMatchers+contain.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F2CFB61039DEF169E7C53C30A589B18 /* EXPMatchers+contain.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		06C0985E9C1A152C93E8F10787898EB2 /* SPTCompiledExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 32F6C9761C5EBF1FD1E2E806B73ECFC1 /* SPTCompiledExample.m */; };
 		0708C5DA97E854727DE72C336EB0CF9E /* NSInvocation+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AE115DD92E26A790115FED62FF0D3CD /* NSInvocation+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		075E4C3FF276BFDB86820DE962CDBB1F /* AvoEventSpecFetcher.h in Headers */ = {isa = PBXBuildFile; fileRef = D4C222E409A85E689ED2359DD9FE5245 /* AvoEventSpecFetcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0762A1BF7F0303179819D66A73A13A53 /* EXPMatchers+postNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = ECF12A02387B6EFCC13650016ADA4C8A /* EXPMatchers+postNotification.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		0945F210CA2FA0ADD947001B34626A1F /* AvoList.h in Headers */ = {isa = PBXBuildFile; fileRef = 4EF29B41E096F8698DD5C733AA6699CF /* AvoList.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		094AC3B25375D25FF6A7445CAD44AD20 /* EXPMatchers+beIdenticalTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 958F6E8E00AC8CA64CA1487C047AF5A2 /* EXPMatchers+beIdenticalTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		09704CEB1A09B47131824C22AD6B092B /* SEGReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = C9485FE00D528E73468E8626474AD42B /* SEGReachability.m */; };
 		0A58DB87B4A15B7D61EB5B42CAC9BDA4 /* EXPMatchers+FBSnapshotTest.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C8FF9000F5FE6BFEBF6B6491F152533 /* EXPMatchers+FBSnapshotTest.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0BFA8ADBBE5C374CF644D541D7282A01 /* OCMBlockArgCaller.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E297C6EAFD444E2920F2A5E1CF49BC2 /* OCMBlockArgCaller.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		0C0D31B3765120C19ED0CB98924B5EF2 /* FBSnapshotTestCase.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F0D75107EE9C5C5273A5BA6F6E5F618 /* FBSnapshotTestCase.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0C118C0B26DB7AC928BAD64DC9DDED84 /* EXPMatchers+endWith.h in Headers */ = {isa = PBXBuildFile; fileRef = 91C21EC47774D557EC1A8B69745A2525 /* EXPMatchers+endWith.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0C175F1524C1B9FD8C070E8A4B7CC46C /* NSMethodSignature+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = F30A5C503F1A81D96514140BAD3D22A8 /* NSMethodSignature+OCMAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		0DDEBB356976012786B9D487CEC0DD5C /* OCMExpectationRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = 44DE5A569924A85C16130ECF217C98A6 /* OCMExpectationRecorder.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		0EA2F6B96D7A46FB7CDA648F57EE98B3 /* SPTCompiledExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 32F6C9761C5EBF1FD1E2E806B73ECFC1 /* SPTCompiledExample.m */; };
 		1038906C3B707005FE7AA73C551A5EE1 /* OCMExpectationRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = B6F4B7E28E13DDCA0F6242B8AAF02FAE /* OCMExpectationRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		126E46FE3404804E3F8DD2CDC0B5B4E8 /* SPTCallSite.m in Sources */ = {isa = PBXBuildFile; fileRef = 9223479EA77FBA1BD66D805B46ADB563 /* SPTCallSite.m */; };
 		12C0754D58F6B2DD4EB034463257D3A4 /* Analytics-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 04F6B0B6A4201AA64DB0854D4F1CA1BB /* Analytics-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1333BFD0118F938E2EC7BE4B6B44B961 /* SEGHTTPClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 8DC1A11306E2D09A0BCF6B078639CFB2 /* SEGHTTPClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		136CC1AB5D2124118E850DC21BD591B5 /* EXPMatchers+beGreaterThanOrEqualTo.h in Headers */ = {isa = PBXBuildFile; fileRef = A6901D56ADBDE182301B992FB8559847 /* EXPMatchers+beGreaterThanOrEqualTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		144C85681813A481F265F1BEB5134249 /* AvoUnknownType.h in Headers */ = {isa = PBXBuildFile; fileRef = A9E9475BC83D816365989EC0B6C35DE6 /* AvoUnknownType.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1464C324652605EC79387E66A9325A55 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5007A65FD3E11CD2D12AE75A04744D1 /* QuartzCore.framework */; };
 		157E6204F395E1819EC388A22125E0AF /* OCMExceptionReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E3F1168FB038BF6F34EBD05E76B1FF0 /* OCMExceptionReturnValueProvider.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		16018D4538AE750B703AE0E6603A4530 /* EXPMatchers+beInstanceOf.h in Headers */ = {isa = PBXBuildFile; fileRef = F2BC63153CAE845052DE6CBD718231A0 /* EXPMatchers+beInstanceOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1622F825EA7A3B0BA4664487AA607613 /* OCMObjectReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 34B9F5D2B054D1C634C2FBAAC2E4D030 /* OCMObjectReturnValueProvider.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		168E197353F0AD472DC4D5BFE3E7084D /* OCMLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 67355AB3E762346A41BB551A989E28AF /* OCMLocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		16BC8584B24A5BE53B3B297EBE45EE7A /* AvoEventValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = 47E02A6E51EC790668D4CEB2A6DEB11F /* AvoEventValidator.m */; };
 		188E90D078A049DF0DCEF6C4B740347E /* EXPMatchers+beginWith.h in Headers */ = {isa = PBXBuildFile; fileRef = 5EEB529D2A5C9FADB580D35E17A1AFED /* EXPMatchers+beginWith.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		191FCCB042A8529A23956842A8AB6335 /* SEGHTTPClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 86A50513EA76FC0DC323220143C1AAC2 /* SEGHTTPClient.m */; };
+		19728061FA1AB24A36AA644F34B98447 /* AvoObject.h in Headers */ = {isa = PBXBuildFile; fileRef = F1AF6F5996B72F2B43C2000663A91424 /* AvoObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		199B2A948B1ED37B0145BAE50FB66108 /* OCMConstraint.m in Sources */ = {isa = PBXBuildFile; fileRef = 4AC17C97422DB26268BFC89AEADBE9BA /* OCMConstraint.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		1A195F1D4B04A025A5CB588DC08BFAE9 /* AvoObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 47F46E7E2A83F59389AB4F37443FF89A /* AvoObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1A43286B5406470FF821567E8513AAE2 /* EXPMatchers+beginWith.m in Sources */ = {isa = PBXBuildFile; fileRef = 177D254CC0B34EE140561EC6EFAA80F0 /* EXPMatchers+beginWith.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		1B5715568646C78FC28AE6B490E2715D /* SPTGlobalBeforeAfterEach.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D6BA60AE9110C2706FDC49078E2B9C6 /* SPTGlobalBeforeAfterEach.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1B5A13D93D71FE76DFFAE695E2B399B5 /* SEGFileStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = C0DDC7EE19BA24F7E1159D83D9EEBBF1 /* SEGFileStorage.m */; };
-		1E0329DF5BAF0EFAE5A97C82CC9B86AF /* FBSnapshotTestCase-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = F6349CB56C9BE5592A69B056A5E70E5A /* FBSnapshotTestCase-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1E2CEBB515AF3056E15AD96A0DBD2491 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A28A1D54B29BA3856CF4E339E8F0AF37 /* UIKit.framework */; };
+		1E5C1BD831C5D56ECBE6E975887B6710 /* AvoFloat.m in Sources */ = {isa = PBXBuildFile; fileRef = 2E0378F169A2652F65528D95369711E5 /* AvoFloat.m */; };
 		1EA0FCCB78245BD2C182CF846B3E6751 /* EXPMatchers+beInTheRangeOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 5EA00C4B641AEB3EADE1D4AF365CDCBB /* EXPMatchers+beInTheRangeOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F71132F5B315D42EFEC30A4A8CAFAB5 /* UIImage+Compare.m in Sources */ = {isa = PBXBuildFile; fileRef = 15EA70C682EAEB6BD2F3FA28CCCD9B25 /* UIImage+Compare.m */; };
 		1FCF56EE89D5B1E527C849B36D9BF3AF /* SEGPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = 3FF9CF94967A0B1AF2E8CB3D42A892C6 /* SEGPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		208133EE2C10CF99B527654E31B2BB35 /* EXPMatchers+beTruthy.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C3A3962788405C1AA7E4E6C040C5CBF /* EXPMatchers+beTruthy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2282AFBEDF824EA49DC6CB4C3E4E2D8B /* AvoEncryption.m in Sources */ = {isa = PBXBuildFile; fileRef = 7277418CA65ABAD91856DBC474B383C3 /* AvoEncryption.m */; };
 		22D05B7D1780F23AEE1D9DDD675CB545 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6FD9D030738482969FA185B5402D2F8D /* Foundation.framework */; };
-		23247ABB3C58D4411D6F0598CF136FD3 /* FBSnapshotTestController.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A1C823D31251CBB362600D8585E72E /* FBSnapshotTestController.m */; };
 		236357C0F0D068972B928EE6B21529A5 /* OCMFunctions.h in Headers */ = {isa = PBXBuildFile; fileRef = 6C7037CD2D1271745FCAB310773A2AD8 /* OCMFunctions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2439A0A6F5C2E0CF42A69A23018B7820 /* XCTestCase+Specta.m in Sources */ = {isa = PBXBuildFile; fileRef = 0791ADF7811A716A85EDDAE31FD5D0D7 /* XCTestCase+Specta.m */; };
+		23E708790314D7A959DBF4BF47B63FD8 /* AvoGuid.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B1FE2AD6DEC12989C6C43975BDD1230 /* AvoGuid.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		24454113C56A00F5508DED75902125DF /* EXPUnsupportedObject.h in Headers */ = {isa = PBXBuildFile; fileRef = C0EEFEAEEBFCF07336C1D6E6A2B70775 /* EXPUnsupportedObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		24A599BD3012C748C8AF1FD11361F528 /* SpectaDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = 211AC8777EAC8F6EF904221191957846 /* SpectaDSL.m */; };
 		24BBC75D24E853C2A25B33E21CB24CB5 /* EXPExpect.h in Headers */ = {isa = PBXBuildFile; fileRef = 7DAB211B9552E88B302BAA3B9546C510 /* EXPExpect.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25BBF9AF6A935A06F5ADD8CB5EFBDE26 /* SPTSharedExampleGroups.h in Headers */ = {isa = PBXBuildFile; fileRef = 860B2E29A2F03787759B21D4B7D7765F /* SPTSharedExampleGroups.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		26624BFAD48BCCFB28241872DBD12B70 /* EXPMatchers+match.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D43C69422329C9A2615E85C82A44D83 /* EXPMatchers+match.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2664E2A2A3A14B1B7B4C879D4E3CAB1E /* EXPMatchers+beInTheRangeOf.m in Sources */ = {isa = PBXBuildFile; fileRef = A1FEBA2788095607F65091A7E712D455 /* EXPMatchers+beInTheRangeOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		273B99CB582E0EB46D675A2A90D72E3E /* EXPMatchers+postNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = C7AF1865DD3A3C49C81D26035B35FCEE /* EXPMatchers+postNotification.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		27CD75AB87BC2CE912EF0713EDEBF3F1 /* AvoGuid.m in Sources */ = {isa = PBXBuildFile; fileRef = 70E6B4E2105C14C4F2273B9348DC30C8 /* AvoGuid.m */; };
+		296C793770EDB159E640DD9A83E86103 /* AvoEventSchemaType.m in Sources */ = {isa = PBXBuildFile; fileRef = 39D40952AB64E5374262554E98BE6A6F /* AvoEventSchemaType.m */; };
 		2AB6ED817EBBF5867B82DC1656AC287F /* OCMQuantifier.m in Sources */ = {isa = PBXBuildFile; fileRef = E3B4DE6E725CD4188B3F3B7FBECDEA39 /* OCMQuantifier.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		2C12465A7F70CF000296297E3F9D9B6A /* EXPMatchers+beNil.h in Headers */ = {isa = PBXBuildFile; fileRef = 25C39B0CB6DBA1AA05A773890F51C760 /* EXPMatchers+beNil.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2C8296EEF1C05BA808C028E89BAC669B /* EXPMatchers+FBSnapshotTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 592F53BB2CD6AB34D294F5F0A52CA5F3 /* EXPMatchers+FBSnapshotTest.m */; };
-		2E137A02EC19518FEFB306C8C95157EB /* AvoInspector-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F822A7A01960459C00E77F4AB5923A81 /* AvoInspector-dummy.m */; };
-		2EBC4CFE193EBF26B810F8564FDBC8E8 /* AvoBoolean.m in Sources */ = {isa = PBXBuildFile; fileRef = B3A49134759A9800259E2801FDF90492 /* AvoBoolean.m */; };
+		2DF6F1296C0961D4FB6E638978EDE21C /* SpectaDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = 211AC8777EAC8F6EF904221191957846 /* SpectaDSL.m */; };
 		2EBE4C64D0D66550C21C3A7FD7F99D9D /* EXPMatchers+beInstanceOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 93EA8310ABDAA78099CF7FA473D5916C /* EXPMatchers+beInstanceOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		2F8877AFC58AE55B695425D8256F36F9 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A28A1D54B29BA3856CF4E339E8F0AF37 /* UIKit.framework */; };
 		304BB73DD5021D5EE9F223EB3435B024 /* SEGGroupPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 113B2CAE98B17CD72E794713875778DD /* SEGGroupPayload.m */; };
 		33F4F23DB07805FEFD529A196EC81BD3 /* SEGMiddleware.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A54659396B0B36448F048EB9492C5B5 /* SEGMiddleware.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3495365E20ABCB861BBE53E420400E2F /* SEGAnalyticsUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = E7F9C7F5DF9639A7953FBD51132A691D /* SEGAnalyticsUtils.m */; };
-		349E64192EE5F700FFB9AEBFC60F60F6 /* AvoNetworkCallsHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 62636EEA0826F8656B9FA53FE4CED721 /* AvoNetworkCallsHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		35714043AFA4A26EC949FC29695F7C85 /* SEGAnalyticsConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C14B8692C087275D78499799CEB73F0 /* SEGAnalyticsConfiguration.m */; };
-		3595E26C063B290D9547DD576597FA02 /* AvoInt.h in Headers */ = {isa = PBXBuildFile; fileRef = ED2BCE000322D29BE433E9221F9BC75A /* AvoInt.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		367EDE22611A7CFBA4DB12585FB9FDE5 /* OCObserverMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = ADB08FED406212B6FDF0660E33120258 /* OCObserverMockObject.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		388186EEF217626CA1E2C36767769147 /* ExpectaObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AC489B147CCC8DC210B02F26617DC31 /* ExpectaObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		38B7944E5B5CDB1073BF0296844E53A9 /* EXPMatchers+raise.m in Sources */ = {isa = PBXBuildFile; fileRef = 5270164420BFFC169625EE2BACB69249 /* EXPMatchers+raise.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		397E30E502F1D61B281784E64B472E8F /* Expecta-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 317E9459C25AA634FC7C6FE885E1CAF2 /* Expecta-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3AD206F8263B9E091EC800594666F2B6 /* UIApplication+StrictKeyWindow.h in Headers */ = {isa = PBXBuildFile; fileRef = 19E84F6CA58959C8A74659B791DA68B9 /* UIApplication+StrictKeyWindow.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		3BEFC108997C4E13510E85FD1C903FE1 /* Pods-AvoStateOfTracking_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 424DA1E344161CD577F480FB19D837F9 /* Pods-AvoStateOfTracking_Example-dummy.m */; };
 		3C4BCCB15317300EE21CF929E2FB3B14 /* EXPMatchers+raise.h in Headers */ = {isa = PBXBuildFile; fileRef = 23B0F429FEE76D8326C7F2F8F878C9B7 /* EXPMatchers+raise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3CAA15491A5B2E0B1EE0A54C428E8A65 /* AvoUnknownType.h in Headers */ = {isa = PBXBuildFile; fileRef = 7724BA2B5BCF55DA67AF6871B5C2AC1F /* AvoUnknownType.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3E00FCBD6420800460B86D532FDBC42E /* Analytics-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D6F4C93809358945C92ACF497AF4804D /* Analytics-dummy.m */; };
 		3E2E95DC803B093E2DED5D6E3319EF13 /* EXPMatcherHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = F5DCB74EADEB23944B3B9AC4AE45563B /* EXPMatcherHelpers.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		3E40BCF4A7388DF5ED3C574A4D41065B /* UIImage+Compare.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F98DF9AE350D4C80B9BB54E8BBD792C /* UIImage+Compare.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3E572D98E46359D0406C19C5FB721291 /* OCMQuantifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 287516F366A409A3E64F4F7CC6F01D07 /* OCMQuantifier.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		40080F575ABB87CDCB9D4805EE582EEC /* Expecta.h in Headers */ = {isa = PBXBuildFile; fileRef = 66535179E85E010D20899D729CF4A0CE /* Expecta.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		403FC20C73363BFAB802F070FC0BAB90 /* AvoDeduplicator.h in Headers */ = {isa = PBXBuildFile; fileRef = E732305A85BEB916577CA35320C790BD /* AvoDeduplicator.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		40472AB3D35234CAEBE2E3FD23A56A8D /* SPTExcludeGlobalBeforeAfterEach.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FD96D6BCA96E12AF1CC59350536E18F /* SPTExcludeGlobalBeforeAfterEach.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		40AB494E9D6FAEBC799BADF473314B74 /* OCPartialMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 06295C13CF238D9B9B4D8A9611FC619C /* OCPartialMockObject.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		40B87962E9D7D89B2BE425367DE82457 /* SPTTestSuite.h in Headers */ = {isa = PBXBuildFile; fileRef = CD53A67DC11CD79B70E9160EC7AC07C2 /* SPTTestSuite.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4181069A7E10F9336C7904AB2DCC4354 /* EXPMatchers+beIdenticalTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 525D8DB78FDFE58A73ADAE60D151044F /* EXPMatchers+beIdenticalTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		427D2BF60A12C9BC222209ED856C0AB6 /* NSObject+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = F8A112AFB4227A4D0980F5746F9C2A5E /* NSObject+OCMAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		429200C00789F2352232E9660866C8CA /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69F73B6C90468A4F6F6D7185C76B627E /* XCTest.framework */; };
 		42B0949B8E7DD8C8F01CA9950A088AD3 /* SEGMiddleware.m in Sources */ = {isa = PBXBuildFile; fileRef = 19B56C27C43A40787AA0464EFAABBEFC /* SEGMiddleware.m */; };
+		432BBBF456945047CF7E4FFAC80B1D65 /* AvoEventSpecFetchTypes.m in Sources */ = {isa = PBXBuildFile; fileRef = EC2E169879776C38C36D0887B44E3213 /* AvoEventSpecFetchTypes.m */; };
 		4334A5A9363F8B97049D872767D2C2AD /* EXPUnsupportedObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 59CE28B702AFEC852367744DA180A7DD /* EXPUnsupportedObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		43758840B84246A4E7F02794BF2D938E /* AvoObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F66215985DAEABCF94FEA07E35F2641 /* AvoObject.m */; };
-		43ECD6B4249D68E3079A5E03A04E7E45 /* AvoStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E782B26D2EF872071701465F10F46A8 /* AvoStorage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		437B538A1E68D0D267EF463CBFC465A2 /* AvoFloat.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FEDD12D0E95E06CDA3A818F48C93AE6 /* AvoFloat.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		43B57611BA1383C7D520F966D19B0AE2 /* AvoDeduplicator.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B074C672344ACE03111514BD1434E42 /* AvoDeduplicator.m */; };
+		43D5C2A5619DC92B19A60B0C015AAF03 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6FD9D030738482969FA185B5402D2F8D /* Foundation.framework */; };
 		44F7B9DC077B1896BB1F21960EE11813 /* EXPMatchers+beGreaterThan.m in Sources */ = {isa = PBXBuildFile; fileRef = CE7C80AE372612043592D40888C9D2A8 /* EXPMatchers+beGreaterThan.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		4517240D81F46D7837453CF7D900DB67 /* Specta.h in Headers */ = {isa = PBXBuildFile; fileRef = 51B8CAB25EDB0C9EC599C062026D5652 /* Specta.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		451C399D2C466248D51DFBC0C2170C77 /* SPTTestSuite.m in Sources */ = {isa = PBXBuildFile; fileRef = CE2054E2EFC8A89E9277A44FB810161E /* SPTTestSuite.m */; };
 		455821224A907E350BB43C46F16516F1 /* SEGTrackPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = 7742409ABC834535B941E461617DD66B /* SEGTrackPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		47C488EC9FBC5842632D7E64AEF82A94 /* FBSnapshotTestController.h in Headers */ = {isa = PBXBuildFile; fileRef = 52B484650A9CAD7F15D3D8CC26049E1C /* FBSnapshotTestController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4708123091267CBFC1B72D552F425DAD /* FBSnapshotTestController.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A1C823D31251CBB362600D8585E72E /* FBSnapshotTestController.m */; };
 		48B5038ACDF0BC93340A4E4197FE6D75 /* EXPMatchers+beFalsy.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DD31A82B8259C5394A71DDD548A8D9F /* EXPMatchers+beFalsy.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		48F7B8EDFFA349E940F9A12570099B70 /* EXPMatchers+beCloseTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 6D127215D32F3007A901315786F2AC69 /* EXPMatchers+beCloseTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		49361FACCA43C555F0EBBD4AB666358C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6FD9D030738482969FA185B5402D2F8D /* Foundation.framework */; };
+		4A4529E44836A05DA1F37F7A72FAEA40 /* SpectaDSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AF446D88411CC76180F5A9A4EDB8540 /* SpectaDSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4B0647338C401803BE40D4E63893E394 /* AvoNetworkCallsHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 978C57D230C03D13B4B87709F074A17D /* AvoNetworkCallsHandler.m */; };
 		4B534E5FBE1538D7AE81E4EDA81CC88D /* SEGSegmentIntegrationFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 598059DB73C78C941F3635B70589E64E /* SEGSegmentIntegrationFactory.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4B5DEF09462A94DC2BDB4B21C06D6B9F /* FBSnapshotTestCasePlatform.h in Headers */ = {isa = PBXBuildFile; fileRef = D32F418D184BC8A122AB17CF79DB7F7A /* FBSnapshotTestCasePlatform.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4BCBE0C02E55B339599BA97EE73192D6 /* FBSnapshotTestCasePlatform.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D2B31F7254828169182A9E62E26C6CE /* FBSnapshotTestCasePlatform.m */; };
 		4C24330516EE1B4ED7AD85D1F07DA3D8 /* EXPMatchers+endWith.m in Sources */ = {isa = PBXBuildFile; fileRef = 1ACB02AA0155EB39A45A8C14B6ACEB6A /* EXPMatchers+endWith.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		4C64315AFD11527D11C76667A29C140E /* UIImage+Compare.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F98DF9AE350D4C80B9BB54E8BBD792C /* UIImage+Compare.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4D6A36F9271F6D8FC9CBED7F9461FB69 /* AvoNetworkCallsHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = C3F0FB594533465FEFC208DE37070108 /* AvoNetworkCallsHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4D9AE087718E3550648C2F1DC73466BB /* SPTGlobalBeforeAfterEach.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D6BA60AE9110C2706FDC49078E2B9C6 /* SPTGlobalBeforeAfterEach.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4EA2DE04B78116EA8FDA647667496162 /* Inspector.h in Headers */ = {isa = PBXBuildFile; fileRef = D5379B80E1DFF854F55F4AF937493F3F /* Inspector.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4F7C81475B9B45A70B7B87859FBB9291 /* AvoNull.h in Headers */ = {isa = PBXBuildFile; fileRef = BFE9216CA56AE869328FE543F9533EBC /* AvoNull.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4FD6D6F6600FF8148B058B8DA0707889 /* OCMObserverRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = ED301411CB1F794E1EA1CFF291DC6720 /* OCMObserverRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		4FDB61C075769A94013965985C04FAE1 /* OCProtocolMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 39A58F2F671771EE0C83E7F0ABF08DD7 /* OCProtocolMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		4FF0D127E423572646DE82C0F5F26FD1 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69F73B6C90468A4F6F6D7185C76B627E /* XCTest.framework */; };
+		5040F523403BF08DB74ECA75991FC8AE /* UIApplication+StrictKeyWindow.m in Sources */ = {isa = PBXBuildFile; fileRef = BC6C25497ADFD74DA84FD51E24FBD427 /* UIApplication+StrictKeyWindow.m */; };
+		5042D6A9ECD7BA222DB1C809B0FC77E1 /* AvoStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E1EB07A2558B365D82EC9A5DE4CE430 /* AvoStorage.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		504D560F1F6B8EB5834A3F9B6A6E695B /* EXPMatchers+beLessThanOrEqualTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 5EADDA48A99FE27919246804170F2570 /* EXPMatchers+beLessThanOrEqualTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		51712B47CD40E8B488EB44FD692E5D6F /* AvoAnonymousId.m in Sources */ = {isa = PBXBuildFile; fileRef = 8084EB7CFDB784609B9228960BD5E14A /* AvoAnonymousId.m */; };
+		51CABC8AD6F121D6DC9B55E04AFE23B0 /* FBSnapshotTestCase.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F0D75107EE9C5C5273A5BA6F6E5F618 /* FBSnapshotTestCase.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		52F099AFF3BE6C065CF51F4FCB9EE22B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6FD9D030738482969FA185B5402D2F8D /* Foundation.framework */; };
 		53309D231254E2CE2792FE77AE96A9B3 /* SEGAliasPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 623A6CBFBD914F31689348E3E9249169 /* SEGAliasPayload.m */; };
+		53C3ACEEA2B33E51AF1CDCD9D6BF257D /* SpectaTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 1143669D433AB56E303E508BD7217746 /* SpectaTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		53DE00809F02D6C35473D18522BECF67 /* AvoObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B915E7F7FECA66AF5CC22E749A71230 /* AvoObject.m */; };
 		5610338F0BE5790C5410959D3C70FCDE /* SEGGroupPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = 9EDA2266AEC61739C4732CA1252C2747 /* SEGGroupPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5653F37491E5FD8827D0877A63042F4F /* AvoSchemaExtractor.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D00522674DC08BC7BE6DC6822ED1E5F /* AvoSchemaExtractor.m */; };
 		56AAF540D3BC5EE3A34B8062236F95FD /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53B732FB00D232E5F4123FC655F07E80 /* Security.framework */; };
 		57FDED72346CB1037CC288CDF9986775 /* SEGContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 056502C2EBAC383B525AF2DC29555563 /* SEGContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		58E160D27CD8B479D2738E4506EA1E23 /* SEGPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F77461A7ADDB8C1872D237D2404A12A /* SEGPayload.m */; };
 		58E76D805B58CA88E62E8CD31C1EF7B0 /* SEGCrypto.h in Headers */ = {isa = PBXBuildFile; fileRef = FE74E167A27584EC09C74A47628ADB14 /* SEGCrypto.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5944EF48107BFE53BAFD5789D141E97E /* Pods-AvoStateOfTracking_Tests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 733B45146CD181DE2AA25562F2013BE0 /* Pods-AvoStateOfTracking_Tests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AA24B90FB7B773E77CDD179E9A7D2D0 /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42FE77B7423D0A132C6489563F6E819F /* SwiftSupport.swift */; };
 		5B0E7991CA9F44AE2A0F6947348D5C80 /* EXPMatchers+raiseWithReason.m in Sources */ = {isa = PBXBuildFile; fileRef = 9AAB4B8649A219B3831EC0C635F3EC40 /* EXPMatchers+raiseWithReason.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		5C9F8854FFBF5719D03A883A008F7C52 /* FBSnapshotTestCase-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 7CDFAACF25C58B6397D17517F80B0840 /* FBSnapshotTestCase-dummy.m */; };
+		5B500DB71E67ECF02498B0FB1A1D90FA /* AvoInspector-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 9CDA5569773A911B202D725A6F48C164 /* AvoInspector-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5BDF4E14FFEA4707A68E8814AF0B990A /* UIImage+Diff.h in Headers */ = {isa = PBXBuildFile; fileRef = BB1732BFBFB65C844C7A44B2D7FFB24F /* UIImage+Diff.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5D0341A49C5C0A00DD7F8680FA4735EF /* OCMInvocationMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 45625B4E4291B0BD9E3483058B31D11C /* OCMInvocationMatcher.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		5E0FCAB1E6522DB1FF76A4B2827B6C4C /* OCProtocolMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 91032CE614CFE5F7F74539CACE55AD20 /* OCProtocolMockObject.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		5EC8C5EFF9F57C8B48B1C4A82D2B2AAF /* SpectaUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = 667C0ECC16F0AF57265EF3EAE776A4D4 /* SpectaUtility.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		61217D0D0305CC5C8CBA6B565850C5EF /* OCClassMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = D01EC2FD36930C96F8C76E873B521051 /* OCClassMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		6162B6EDB05F4A0A1DEB2BBFA1BC661C /* AvoEventSpecFetcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 2399E226A9877FA4E9CA3119E64790CF /* AvoEventSpecFetcher.m */; };
 		61E87C43C893D8CECF9832F0FC8BB704 /* EXPBlockDefinedMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = C04527F50C4D4E7833EA6D4FDC247B35 /* EXPBlockDefinedMatcher.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		628B32090C829774A79B9F0ACD9A0A67 /* SEGAES256Crypto.h in Headers */ = {isa = PBXBuildFile; fileRef = B7CE1D904E4CF1FBA6AD580DC6DBCDDE /* SEGAES256Crypto.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		62972A2604C4C9CCEB6EA2A68CF7E196 /* AvoEventSpecFetchTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AAD8ECBAF0BA9FA35ECFBB212D21ACF /* AvoEventSpecFetchTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6312C927DDF10CD4C35E3149D6B4F6ED /* UIImage+Diff.m in Sources */ = {isa = PBXBuildFile; fileRef = 390AC0A95284C24AE2EC56A8F037352B /* UIImage+Diff.m */; };
 		634A79630B41662134DBD12F9A7AEA87 /* ExpectaObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 45CACC982D5641B635B19AE3F78AA37D /* ExpectaObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		643E76C114DF2BC72F9F939C7BE03126 /* AvoString.m in Sources */ = {isa = PBXBuildFile; fileRef = F1FADC3424633DA8A2362EF57E408A86 /* AvoString.m */; };
 		64434E2336169C6A2A37AA2D9BA1B37B /* EXPMatchers+beLessThan.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D29A103319798B4AF0960C0CF0A0AD5 /* EXPMatchers+beLessThan.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		64618C119DD372AA7156E4C81F77BF55 /* EXPMatchers.h in Headers */ = {isa = PBXBuildFile; fileRef = 84409646C7031228B295AD9592A68E95 /* EXPMatchers.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		648934D6C0F146B0CA90FF8C1319D3A6 /* SEGAnalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = BAE6C3D2DDEAFB47A7CFB8DBA640A335 /* SEGAnalytics.m */; };
 		676B0A2964C4229DD2DE721C641DCB17 /* SEGStoreKitTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E4B33DE716B0DBF5049C29BE873AD9E /* SEGStoreKitTracker.m */; };
+		689AFC19C878AC4737100A4E9CFC8A45 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69F73B6C90468A4F6F6D7185C76B627E /* XCTest.framework */; };
+		6937C9A85FFD690DE4A83FF5C2BD8F88 /* SPTSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = 93E281E64A60B7EE7E1915D8F0BA8D0F /* SPTSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		69AD7AC53FA616AB049BC3A8982A9551 /* FBSnapshotTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = BF56796BCB4D909B3C9F786259E60F7A /* FBSnapshotTestCase.m */; };
 		6A2C590083BEF1DA70E0DDE52F69EDC2 /* OCMPassByRefSetter.m in Sources */ = {isa = PBXBuildFile; fileRef = ED8ED6AC142CCB3989148E8C104B5563 /* OCMPassByRefSetter.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		6AA117C5CE53562773840CB83BB3F06E /* AvoEventSpecFetchTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 92CB4D38795C5907816E28F955B48160 /* AvoEventSpecFetchTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6ACBAB7981C7E257408E7A452D46E411 /* Expecta+Snapshots-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = DC4BFE4E1FEA914279F802CBF41EE034 /* Expecta+Snapshots-dummy.m */; };
 		6DA0DD788B98D362D59A10457F703006 /* SEGSegmentIntegrationFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 58749FE58FAC14C6FA5FEC67D826FC0A /* SEGSegmentIntegrationFactory.m */; };
-		6DFEB71D8F43B37AE2BFD5A07DAE8B94 /* AvoSchemaExtractor.m in Sources */ = {isa = PBXBuildFile; fileRef = 38E7D075617A98BFF1264F9557387DBD /* AvoSchemaExtractor.m */; };
-		6FB4D5569ABC35CCA8C236D1B8F15139 /* XCTest+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AAF47C1B5566006F28567349B8383AB /* XCTest+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6DAB9C1FF49654B7792C92ABB0EBF1C0 /* AvoBoolean.m in Sources */ = {isa = PBXBuildFile; fileRef = DDC8740D93D55A37485D5696466F8FF6 /* AvoBoolean.m */; };
 		6FEA4C7F755047EC32F193B8FED7D031 /* OCMNotificationPoster.h in Headers */ = {isa = PBXBuildFile; fileRef = B3B95C173157B2241C14240E19E4F8D6 /* OCMNotificationPoster.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		718B31D55E36963BC9E28AED5FCDF20B /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42FE77B7423D0A132C6489563F6E819F /* SwiftSupport.swift */; };
 		73034E19126EFCED2061825C42CAD9C1 /* OCMock-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = C7FF9A52C7EDA26E8077A15FB096507E /* OCMock-dummy.m */; };
-		76E098596DEDDF7784244C28C15AC624 /* AvoNetworkCallsHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BD7E9F680E4AF560BFC8074CB38F034 /* AvoNetworkCallsHandler.m */; };
+		74E44A604797A9F902C0F812501A7C75 /* AvoInspector.h in Headers */ = {isa = PBXBuildFile; fileRef = 59B03BE100305444A2C4AA46124C532D /* AvoInspector.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		769096945F6486DCD3F3E684E52FC9A8 /* XCTest+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AAF47C1B5566006F28567349B8383AB /* XCTest+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7843336BE345C5EEA5A3A431003D3C1E /* EXPMatchers+beLessThanOrEqualTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 49647D9B9EA69796980669F1E5D0EC73 /* EXPMatchers+beLessThanOrEqualTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		7872D01839F3B488693D15EF1D4484DC /* AvoSchemaExtractor.h in Headers */ = {isa = PBXBuildFile; fileRef = 618B007074A8ADB69E39EC1F7DF7F7B4 /* AvoSchemaExtractor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		78AFD64E8328157CB1030F08D004318E /* AvoSchemaExtractor.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FFBEE081D2873A076F7BC3DFD9593AE /* AvoSchemaExtractor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		78C7133154521B8C9053B21714E533D1 /* AvoUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = DB0FCD211D625E73AB05085B50615ADA /* AvoUtils.m */; };
 		7A63B2F114A55CF257ACF300D08A446C /* SEGAES256Crypto.m in Sources */ = {isa = PBXBuildFile; fileRef = 4901497783016C7F801E370251405689 /* SEGAES256Crypto.m */; };
-		7C09D4723035233E8F0F07EC7AD2D17C /* SpectaUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = 667C0ECC16F0AF57265EF3EAE776A4D4 /* SpectaUtility.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7C3C833FEB61AF039DD17B541B33AD12 /* AvoGuid.m in Sources */ = {isa = PBXBuildFile; fileRef = B53B03FE51473DF05F79B4A61BA3C381 /* AvoGuid.m */; };
-		7C8160F46148AB5574413DE76522B28F /* AvoUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = CAF06CF564FB71A1B0FF2732C4014659 /* AvoUtils.m */; };
-		7CD4FEA89658341CF06CC1860F8B79E5 /* SPTExampleGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B554258FF17C502915BCE79344087DD /* SPTExampleGroup.m */; };
-		7D6855F7809E71FBBDF11E8642352B2B /* AvoEventValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = 0C743BD8948F4C76B052292B1D33ED6F /* AvoEventValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7A6F9297CE2E19A667F3491F635DDDD7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6FD9D030738482969FA185B5402D2F8D /* Foundation.framework */; };
+		7B490722589857374E21E3F6D9F783A6 /* SPTExample.h in Headers */ = {isa = PBXBuildFile; fileRef = BAB35ECF4279470E561AD0CDB58D632D /* SPTExample.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7DE588F368488DC94290965EE02CE9CE /* AvoEventValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = B2C3DBD54E74DFE6F68A326C4C73C41A /* AvoEventValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7E222B1E3746A0B2EFB19D7C6436B2D1 /* NSMethodSignature+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = F0A136C08DE3FC6D96E7B4C27DA6CEA4 /* NSMethodSignature+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		7EFB8CF844CCA75397332B13F04133EF /* XCTestCase+Specta.h in Headers */ = {isa = PBXBuildFile; fileRef = 8771FE0109D744D85FF4312DF5F07865 /* XCTestCase+Specta.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7F4A5C422A2BF4D9BAAB76C3027A6E5D /* EXPMatchers+respondTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F01EE3CB23DBACE6031AC0C708F9835 /* EXPMatchers+respondTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7F7292C50FFB369954E7E93178CEAF78 /* XCTestCase+Specta.h in Headers */ = {isa = PBXBuildFile; fileRef = 8771FE0109D744D85FF4312DF5F07865 /* XCTestCase+Specta.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		802E4069023C9A6BA9457A77D0C2AF9F /* AvoBoolean.h in Headers */ = {isa = PBXBuildFile; fileRef = 02E4E3B41C978135D4585CC4BF112F7B /* AvoBoolean.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8088D73CA5CC632D197E241132395A61 /* EXPBlockDefinedMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AA095C4CADEA623FEF5A96FEA61F4E6 /* EXPBlockDefinedMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		80A5F6391A250DF910FC2F611948E9F1 /* SPTExampleGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = E4699799B8F7E4ADDB0CC1B364CC5747 /* SPTExampleGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		830F1FEDE8892C0157D17F8DFF9BF050 /* SPTSharedExampleGroups.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E9B7631648F2B80B7039AE2C7998370 /* SPTSharedExampleGroups.m */; };
-		8335B811CC809CB23F8F65C6D0687D73 /* AvoEventSchemaType.m in Sources */ = {isa = PBXBuildFile; fileRef = D541A5CA0804C0BE75FA4EBC855146D9 /* AvoEventSchemaType.m */; };
+		80D2F85F7A5E87010D04D42AD8173CA7 /* AvoAnonymousId.m in Sources */ = {isa = PBXBuildFile; fileRef = 8712A08613885978559646EB7F0574EF /* AvoAnonymousId.m */; };
+		819972C44694E9A918C9BA7FF20A04DE /* AvoBatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = ADD074A6D2F56D7995D2A20543DADB67 /* AvoBatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		83378CAE9048C59660C00C291CA97F32 /* NSValue+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3123BAC06AA368AF8E453A6257DF1F81 /* NSValue+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		836D31E00E8795CFEE0CDC534DD025F2 /* SPTCallSite.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C69E935EFB0CFB33829ECAA85BB435E /* SPTCallSite.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		84799E534AEFDCC7FCA06DDB90CAD611 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6FD9D030738482969FA185B5402D2F8D /* Foundation.framework */; };
 		84ECBDC734AB86F156CC137AA1E3AD17 /* SEGIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = 9BDB14440C65727C9552B805F4E176A5 /* SEGIntegration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		852E3A98FF249B217FB55B8D4E6A70C4 /* ExpectaObject+FBSnapshotTest.h in Headers */ = {isa = PBXBuildFile; fileRef = E0EFFE5BDD07D50C2D11C1027FEB4C41 /* ExpectaObject+FBSnapshotTest.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		85422669E598C9F67135CCF421F5CF74 /* NSNotificationCenter+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 7674422F374DAFAECC6F1D5B4D057CB9 /* NSNotificationCenter+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		8551BE8E0F918616FCF7F022FE443958 /* SPTExample.h in Headers */ = {isa = PBXBuildFile; fileRef = BAB35ECF4279470E561AD0CDB58D632D /* SPTExample.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8592821A266BBE92414F120040F7C62E /* AvoEventSpecFetcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 11E61668DA3D1777A073E4401EC884A9 /* AvoEventSpecFetcher.m */; };
-		85B35C43735F4700EFCEE5B6B2CABDB2 /* AvoInspector.m in Sources */ = {isa = PBXBuildFile; fileRef = 3DA2A8E2329A2740C7293ED9D413102C /* AvoInspector.m */; };
+		8630C4479877E1AE249105EB84C36879 /* AvoEventSpecCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 379BA466768D48F013EE1EA03D708DB2 /* AvoEventSpecCache.m */; };
 		86443C8A32ADB769B8985FBD68F4B99C /* EXPMatchers+equal.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F356EBD6FE4A50892B28F377EAA339B /* EXPMatchers+equal.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		867AFF556CF5DBDDECE208413A08FE51 /* AvoFloat.h in Headers */ = {isa = PBXBuildFile; fileRef = B0FCCB3593AB7973336A143FFE47B7C8 /* AvoFloat.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		86D4A6EDB484462F9DF84B99364455A4 /* OCMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 769D8F9BDD56901054E3612A1D86EC64 /* OCMockObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		87A26817ADACD3FDF4A346212C5819F6 /* FBSnapshotTestCasePlatform.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D2B31F7254828169182A9E62E26C6CE /* FBSnapshotTestCasePlatform.m */; };
-		87F08355A3AA6F9E8185E83D5C104F32 /* SpectaUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 842BC7D4442DB7D6F4BCC728391A32A1 /* SpectaUtility.m */; };
-		89074D6A1FA4312859BE575CE840228D /* SpectaDSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AF446D88411CC76180F5A9A4EDB8540 /* SpectaDSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		888E52DEBEDFD4AD6953C99D59071F68 /* AvoUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 58F22A3684E27B3119E9C19B6068EE35 /* AvoUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8952FDD8093FBA9A9B5256026309D59E /* SEGIdentifyPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = CC24C518F0D66A97FE28F023A2C6949A /* SEGIdentifyPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A58E1FFB52D0B785D55D1787E226DD4 /* EXPFloatTuple.h in Headers */ = {isa = PBXBuildFile; fileRef = 81077B4B065AE8FEAF6E6C3B8396A9FD /* EXPFloatTuple.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8B402D4FD77FC80E56FDF0150BB68B66 /* EXPDoubleTuple.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CCC6EB206B610A5D00EFB8EB44E3AD2 /* EXPDoubleTuple.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8B760AE16665910CA173A2F4F71C10CA /* AvoNull.h in Headers */ = {isa = PBXBuildFile; fileRef = 47788E8E2C73F5264A861C41493D8238 /* AvoNull.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B45D9E27E775DCA16600B63F4EE70E5 /* SPTTestSuite.m in Sources */ = {isa = PBXBuildFile; fileRef = CE2054E2EFC8A89E9277A44FB810161E /* SPTTestSuite.m */; };
 		8C4118171DBD8FFB0D193AB9BB091D62 /* OCMArgAction.h in Headers */ = {isa = PBXBuildFile; fileRef = CF3203ABFD24AC89373B929B927C5FA3 /* OCMArgAction.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		8CC5B7C80144C1D60803B275111DD3C9 /* ExpectaSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 213E978CBCC02F496BF12EED791A7EF1 /* ExpectaSupport.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		8D3163817D51651D15191DF2ACE1D5C8 /* UIImage+Compare.m in Sources */ = {isa = PBXBuildFile; fileRef = 15EA70C682EAEB6BD2F3FA28CCCD9B25 /* UIImage+Compare.m */; };
-		8D43EAA8C65497B48185F4674AE1BDAD /* SPTSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = D85836D70C6ECFA262C7EEF374490F99 /* SPTSpec.m */; };
 		8E79AEB4F7E15F2C75AD6C31EE5C6CFC /* OCMArg.h in Headers */ = {isa = PBXBuildFile; fileRef = C339C5030321B7D40789BB49823794F3 /* OCMArg.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		908BBCE719318468B5E62565839FA362 /* OCMInvocationExpectation.m in Sources */ = {isa = PBXBuildFile; fileRef = 392DB5E6D4CCAEFC74C9DFE101137330 /* OCMInvocationExpectation.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		90B06ECDEBBCCDC8BC8CE768282DDF37 /* SEGReachability.h in Headers */ = {isa = PBXBuildFile; fileRef = B6F22BEDB958A3136549B1D04EF4EA0C /* SEGReachability.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		920B90B6A59F9A8A85D1E143FB28C48F /* AvoNull.m in Sources */ = {isa = PBXBuildFile; fileRef = 20D6FCC49D0C393926D9075D663628B6 /* AvoNull.m */; };
-		92147AF800B0E921BBEA0ED66B03D4CC /* AvoEventSpecFetchTypes.m in Sources */ = {isa = PBXBuildFile; fileRef = 99805C28CAC664ED729B1456ED867815 /* AvoEventSpecFetchTypes.m */; };
+		926086052C0CB34F547F31A55BD6890D /* AvoBatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = C14985C09E15E0916D142E841B41BE0F /* AvoBatcher.m */; };
 		94331277561113D4308BB0DBD6FA05B3 /* OCMArg.m in Sources */ = {isa = PBXBuildFile; fileRef = FFC64F6F4889335B65F1A49636C8205F /* OCMArg.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		9560053588FF0AB7160FF770DB56B982 /* EXPMatchers+contain.m in Sources */ = {isa = PBXBuildFile; fileRef = 560F23459F36F8664C47D721CE275F03 /* EXPMatchers+contain.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		9569C8C2A2DC4DF5062E8526D1925715 /* SPTSharedExampleGroups.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E9B7631648F2B80B7039AE2C7998370 /* SPTSharedExampleGroups.m */; };
 		9569D24A0AB767C86E59D6D337BFE6B6 /* SEGUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = FEE4BD74DA6CF38AF62C2BC40C690B18 /* SEGUtils.m */; };
-		9579B61D8CD4258E912A3190C5239C7A /* AvoInspector-AvoInspector in Resources */ = {isa = PBXBuildFile; fileRef = DBE88333832815438B420B38F0416993 /* AvoInspector-AvoInspector */; };
-		95F28E20A36FA4D3BDF77FB3BD760840 /* AvoAnonymousId.h in Headers */ = {isa = PBXBuildFile; fileRef = A9F3578ABD4F65B3E5BCB1CEE7092373 /* AvoAnonymousId.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9637ED83FED5E1902B8F86D08FE20DC7 /* Specta-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 7103C493E7D2C94D5B260BD3BFA9C521 /* Specta-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		96172600BE9FA960A255DBDFA80682B8 /* SPTCompiledExample.h in Headers */ = {isa = PBXBuildFile; fileRef = 2519B384F889E623BEB7B81246BC4C16 /* SPTCompiledExample.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		964DF667C1EFDF34AC75BF399D8ACEFC /* ExpectaSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 60821DC560B94166DF90F121F0025267 /* ExpectaSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		96C13E279BF7405C667FE59E9595EC18 /* AvoInspector.m in Sources */ = {isa = PBXBuildFile; fileRef = E9700210CA98FDE33B1696F43A998E1B /* AvoInspector.m */; };
 		97707120DEE14A02C6FE096AE5FDD157 /* OCMInvocationStub.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CEEA6F4E749D66E501955DD1DDA6692 /* OCMInvocationStub.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		987BF1DF7C94BA9BE141ED3FC72EA2C0 /* OCMMacroState.h in Headers */ = {isa = PBXBuildFile; fileRef = 609FF4A527F48598E61673CD1AFAC865 /* OCMMacroState.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9929E370BD645542D699663D22550085 /* UIImage+Diff.h in Headers */ = {isa = PBXBuildFile; fileRef = BB1732BFBFB65C844C7A44B2D7FFB24F /* UIImage+Diff.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		99F1C7C5BBC47D7E5A78C08E139CE8CE /* UIImage+Diff.m in Sources */ = {isa = PBXBuildFile; fileRef = 390AC0A95284C24AE2EC56A8F037352B /* UIImage+Diff.m */; };
-		9A8705085F37B28DBEA6CDDE34847509 /* AvoEventSchemaType.h in Headers */ = {isa = PBXBuildFile; fileRef = 71E7DAFB0F08BBB855A57628A42B9341 /* AvoEventSchemaType.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9B51DAB50D6F87169221F77AD58F1DC5 /* OCMBlockCaller.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AABE954A79D6DE416E939693626FA8C /* OCMBlockCaller.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		9D7BFA8A8C19DC1765E7FCE3CE5F4F36 /* AvoString.h in Headers */ = {isa = PBXBuildFile; fileRef = BDEA666C356BE70AD8AA26F5A151EB15 /* AvoString.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9EF547D021393C73B7238640371DE4E9 /* OCMObserverRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = 263A8F0A5DF172C5569DAA8827BE88C9 /* OCMObserverRecorder.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		9F215B3BBDFC816CADE287B4F6324E83 /* OCMMacroState.m in Sources */ = {isa = PBXBuildFile; fileRef = B21D73849F6FA68401D2C5A686F3F390 /* OCMMacroState.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		9F869587CC8D6EAF0D04EA086AF6774F /* SEGSerializableValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 496E92F3AC651E5DAE3F0C6C4CB65718 /* SEGSerializableValue.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9FBC62DEA9A589B661A51FA3CA714996 /* UIImage+Snapshot.m in Sources */ = {isa = PBXBuildFile; fileRef = B3307F68BC7948C6C2B0D789490C8193 /* UIImage+Snapshot.m */; };
-		A0C2195558BF4AF19587BADAEF2A181D /* FBSnapshotTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = BF56796BCB4D909B3C9F786259E60F7A /* FBSnapshotTestCase.m */; };
+		9F9B59978C33C9BEDAB2C94B1CBC77B8 /* UIImage+Snapshot.m in Sources */ = {isa = PBXBuildFile; fileRef = B3307F68BC7948C6C2B0D789490C8193 /* UIImage+Snapshot.m */; };
 		A2E275C9DE20FAD8A7CC2B742D0CB1AB /* OCMPassByRefSetter.h in Headers */ = {isa = PBXBuildFile; fileRef = FDFDD9BE0F0B4763C500012041C6A7F5 /* OCMPassByRefSetter.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		A315A4DEA0CC1A85F46428EEA67DB97D /* AvoBatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = CE4E03A6152FD02F67111E49C036B2E2 /* AvoBatcher.m */; };
-		A31FA4FFCB410754EF1D804E2B9056E3 /* AvoInt.m in Sources */ = {isa = PBXBuildFile; fileRef = A2A9155F3D40E48C863C42E4945E7F93 /* AvoInt.m */; };
-		A3A3DDB0FD9423F3250C907147ED14F9 /* AvoUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = D962E8DD98717C2F4E5B56CA72930AB0 /* AvoUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A597B1D316A2B53D411444403B83D104 /* AvoInt.m in Sources */ = {isa = PBXBuildFile; fileRef = B315AD2E8094367F5673EA0654B86644 /* AvoInt.m */; };
+		A5C383A380B608DA72CC9BB1E620141C /* AvoInspector-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D356E6789FFA488A8D25A1DF6958C45B /* AvoInspector-dummy.m */; };
 		A650077802C47576CA11186CA96327CD /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6FD9D030738482969FA185B5402D2F8D /* Foundation.framework */; };
 		A6B9E2C7ED52EB34F3D27C5C00D2C479 /* OCMFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A2A5CDF6EC4159F1B93B3322DDA053E /* OCMFunctions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		A6BECA443499D660E57DF9B0DC7C8ABD /* SEGUserDefaultsStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 3EA4B91F5A0E0BCCC7DAB9112549BE3C /* SEGUserDefaultsStorage.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A770586D91E2AE41ED8D4D1AE83E1B5F /* AvoBatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 6ECD35C03E8AE0C97FEC4F507D20A892 /* AvoBatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A7984D16FCEBCFBBB5C9A0515B9397B8 /* EXPMatchers+beCloseTo.h in Headers */ = {isa = PBXBuildFile; fileRef = CB6D256782384030E520A854CECC2152 /* EXPMatchers+beCloseTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A8EC406F8F50D1F9A2D4646C1D06BBC9 /* OCMVerifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B9EDABC57F952D4FE467F70928FAFD6 /* OCMVerifier.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		A92E3888903993BC3FED1E48A37BB393 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6FD9D030738482969FA185B5402D2F8D /* Foundation.framework */; };
+		AA1838E30D21D2BD2122B3E3808BBE74 /* AvoAnonymousId.h in Headers */ = {isa = PBXBuildFile; fileRef = F25FC41FBBB86BB5B909408B73977416 /* AvoAnonymousId.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA7A809622B0728B833AE292A178A480 /* EXPMatchers+beKindOf.m in Sources */ = {isa = PBXBuildFile; fileRef = E694CE0F6FD21CAE949C9E3B83CDD786 /* EXPMatchers+beKindOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		AB005363F8859BE8055967763BDAFD03 /* AvoInspector-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 203A5D32352BD7C0791FD153F5930FE8 /* AvoInspector-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AB5B5027D6BD6DD75F1FFC0352C4D90F /* AvoList.h in Headers */ = {isa = PBXBuildFile; fileRef = 14CCB198FEB5532679FF53BA56912589 /* AvoList.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ABFFD4DE8C1420DFA3DE27BE9FEE2DE1 /* UIViewController+SEGScreen.m in Sources */ = {isa = PBXBuildFile; fileRef = E17CA18BBD6AF8C5765DF73136C50564 /* UIViewController+SEGScreen.m */; };
+		ACB1BDF9839C6DD3CDAD841586738ED5 /* AvoNull.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B6A9A5E885251E18289D77441F99C23 /* AvoNull.m */; };
+		AD49198DD9B5607C4D54AB48C398F72E /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5007A65FD3E11CD2D12AE75A04744D1 /* QuartzCore.framework */; };
 		AEAE642454492D2130B81BB99002C425 /* OCMNotificationPoster.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CB67D39164F2836E6C58284DDA8C1E9 /* OCMNotificationPoster.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		AFA7F83A7FE9896F749A341339AB794C /* OCMObjectReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E4D87795C32C491B528F6BD0B0D0A27 /* OCMObjectReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		B07E2148B26D2013EF57D911F25333BE /* SEGSegmentIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D8E0D400C92D7AC033A4D4311E48516 /* SEGSegmentIntegration.m */; };
-		B08C3D6C489980A20D76907C02FEE6B1 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6FD9D030738482969FA185B5402D2F8D /* Foundation.framework */; };
 		B0927C53BD304B0585C94CE2A5F1D04C /* Pods-AvoStateOfTracking_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = D538AE56B9FA797ED14D462EE9542A4D /* Pods-AvoStateOfTracking_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B15874F0ED49ACED8520F22A4779E3FF /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69F73B6C90468A4F6F6D7185C76B627E /* XCTest.framework */; };
 		B1A2BA3BAB8278EBE8867F55D944B6EB /* SEGStoreKitTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = E116588B2D2A51B9C133951E03A039D2 /* SEGStoreKitTracker.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B21A8305FC9DFB75545AF00C73F58400 /* EXPMatchers+beSupersetOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 003C70D44648366E1A1A7A777001F410 /* EXPMatchers+beSupersetOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B23102CA40401D61DB2F9B443455306B /* AvoFloat.m in Sources */ = {isa = PBXBuildFile; fileRef = 6586F0F76E995B08E6A6CF7B3C9EC667 /* AvoFloat.m */; };
+		B3585B3B5FFA3917A1008448D4413564 /* AvoInt.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E3234141BC0E991DA41BAD84FF304C0 /* AvoInt.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B3B010DD962B43242F16302962E7F24D /* EXPMatchers+conformTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 086742AD788D09B08C3F17F3861D0BF3 /* EXPMatchers+conformTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B3F7A438127DD9E7137F58A9167CAD47 /* EXPMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = B7741941AD68BCFC2257F9B4EAFAA6B6 /* EXPMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B5BE044375A8970BC3F083EFFCCE11E7 /* SEGIdentifyPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 28CE5540FC5B22AB910784C7E20153BA /* SEGIdentifyPayload.m */; };
 		B5E66E313ADCAE0EE66E81CABA6AAC01 /* EXPMatchers+beSubclassOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 618F94860D6C572C80DC110EBF8AEB06 /* EXPMatchers+beSubclassOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B6403AF5D22BA28CED164B26F5554F70 /* AvoEventSpecCache.m in Sources */ = {isa = PBXBuildFile; fileRef = D522AA9D98D2EFB77EC6371A3E73D6E8 /* AvoEventSpecCache.m */; };
 		B786CDF7301892D596E3E37DFFCA57B4 /* OCMRealObjectForwarder.h in Headers */ = {isa = PBXBuildFile; fileRef = F1EAE4762AEC1597B642638CCFC68C54 /* OCMRealObjectForwarder.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		B9A1EDCEAA0A09A91E09C7198DE0C675 /* AvoList.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DCDCCB631E371C4BE0D5B4020B2327A /* AvoList.m */; };
+		B95E8D8762F309A4E28A6718E4963654 /* AvoEventSpecCache.h in Headers */ = {isa = PBXBuildFile; fileRef = ED61FDE0E154F68B00CA7E96CD8BEDE2 /* AvoEventSpecCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BA6D116DEB8E9EE61CF5D0218CFAC2EE /* OCObserverMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 805DEFE0420CC0A22DE4AF4022603121 /* OCObserverMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		BB031523FECB849FB0C7D46FE893C955 /* EXPMatchers+match.m in Sources */ = {isa = PBXBuildFile; fileRef = A401BC8F87897E4D26F78A7E5E7A42EA /* EXPMatchers+match.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		BB111E578CC6CECA23E5AB282D30845D /* EXPMatchers+beTruthy.m in Sources */ = {isa = PBXBuildFile; fileRef = BEA410302EA9077EC89C75F9238C30F2 /* EXPMatchers+beTruthy.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		BB87F9F50B295E5A8FB991CAAC11043A /* SEGSegmentIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = 71AD272BFC423106A60A9BAED18D04D1 /* SEGSegmentIntegration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BBAC300838523534801082D79F766851 /* SEGScreenPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = 6AB2C4A3D340E237803DF001A5351C25 /* SEGScreenPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BD68436CB0DC061FD63C93E650217F8D /* UIImage+Snapshot.h in Headers */ = {isa = PBXBuildFile; fileRef = 786C023A1B667A360983EAC0EACF2BDD /* UIImage+Snapshot.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC781426400DB88530D0BD9E79B933F4 /* FBSnapshotTestCase-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 7CDFAACF25C58B6397D17517F80B0840 /* FBSnapshotTestCase-dummy.m */; };
 		BF82C02A22A698DF7224255A0610D112 /* SEGIntegrationFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 05BD759B36050756E0A1DCCE831242BC /* SEGIntegrationFactory.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C03C8F5FE7EB66675E3B7F85AA974D97 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69F73B6C90468A4F6F6D7185C76B627E /* XCTest.framework */; };
-		C0B0F28C4C39773CB8065AFDDF3760B7 /* SpectaTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 1143669D433AB56E303E508BD7217746 /* SpectaTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C13D2F6F72FAD6F17BE42BC77ECCAB7B /* EXPMatcherHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DD14BA05613169A1E45037FB225819D /* EXPMatcherHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C2F2483E936B33C3ECBCADB14A33D659 /* OCMInvocationMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 51184837B70082873A90D7887E84DBAF /* OCMInvocationMatcher.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		C30A7E1682336A5A02B728755B624095 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6FD9D030738482969FA185B5402D2F8D /* Foundation.framework */; };
 		C32AD8AC2C2DC3DB9320CEE6AF49F4F3 /* EXPMatchers+beFalsy.h in Headers */ = {isa = PBXBuildFile; fileRef = EB53F464B5FDB2D0E27095907735E04C /* EXPMatchers+beFalsy.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C36ACD3ABC723E1B0ED60A02CC3FD309 /* EXPMatchers+beKindOf.h in Headers */ = {isa = PBXBuildFile; fileRef = E79C056087F64BE8CFB39AB625574413 /* EXPMatchers+beKindOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C3A10320BF2A6B429CD948481B509FDE /* UIApplication+StrictKeyWindow.m in Sources */ = {isa = PBXBuildFile; fileRef = BC6C25497ADFD74DA84FD51E24FBD427 /* UIApplication+StrictKeyWindow.m */; };
 		C407DAF17A0BD80DE7028781D734FD3D /* OCMock.h in Headers */ = {isa = PBXBuildFile; fileRef = 97479C4E30D1DF03E4C97C85B7EA50D3 /* OCMock.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C40F18F652796051817E52B0A42BC871 /* SEGIntegrationsManager.h in Headers */ = {isa = PBXBuildFile; fileRef = C96C65747FFA546BE09E893C8968D133 /* SEGIntegrationsManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C4A1D05B63C59B11E7D15BC2917B26F2 /* OCMLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8883642E0EC4D8CB56F61BF805E0FA65 /* OCMLocation.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		C4B6F5134FD079F5D06C578E71F6C4F3 /* AvoGuid.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F72FE2576CBFDB3DA6ED0E0B751F289 /* AvoGuid.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C5625F28A4BD1D02CD0EC442257B02C4 /* SPTTestSuite.h in Headers */ = {isa = PBXBuildFile; fileRef = CD53A67DC11CD79B70E9160EC7AC07C2 /* SPTTestSuite.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C7F048E0D6358714F4E0C2378CF6D7A8 /* AvoInspector-AvoInspector in Resources */ = {isa = PBXBuildFile; fileRef = DBE88333832815438B420B38F0416993 /* AvoInspector-AvoInspector */; };
 		C81D3B080248F365C2FCFEAC2616C1A6 /* OCMRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F1BE4636571A539C87EFB0C3AB1C90E /* OCMRecorder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C908D199D60FE8CBDDDEDF41E4FDB4C4 /* OCMArgAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 6F5FAE4D95FB6A9732125A383780A679 /* OCMArgAction.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		C934FD8637050CD8CA03F50519F869C9 /* AvoEncryption.h in Headers */ = {isa = PBXBuildFile; fileRef = B13924B2208998F2F0E3C632E8AB9E03 /* AvoEncryption.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C95B4CE8A5A98F46480FA48E56C8EBA4 /* UIImage+Snapshot.h in Headers */ = {isa = PBXBuildFile; fileRef = 786C023A1B667A360983EAC0EACF2BDD /* UIImage+Snapshot.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		C998CF95A5EE9639D6C2DAC75F1964B9 /* OCClassMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = F5ECA8DF5A40CCF3DD4310D04BB946CD /* OCClassMockObject.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		CA06CFC1EDF192633C505BAA715ADD0B /* SEGScreenPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = F50FB699DAA5E39E121185ACFC9C3471 /* SEGScreenPayload.m */; };
 		CA8CE7F4438A4FF1781E8678E21E5898 /* SEGAnalyticsConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 0879FB7B7BB80196EBB3E1FDE4AC0C30 /* SEGAnalyticsConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CC87EB046273A8816C46B1A537175D2C /* SpectaUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 842BC7D4442DB7D6F4BCC728391A32A1 /* SpectaUtility.m */; };
 		CCACDE1DD1D09D3B66F2E34F81918C6F /* EXPMatchers+beNil.m in Sources */ = {isa = PBXBuildFile; fileRef = EC678BB5550440D42DF6B2FFE94F7A01 /* EXPMatchers+beNil.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		CD62F9B6790D3F44CF7824ECA02939B7 /* OCMRealObjectForwarder.m in Sources */ = {isa = PBXBuildFile; fileRef = DB48450C71C5ADDFC15289FDE17F5776 /* OCMRealObjectForwarder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		CDC0B1BBBF260044F4FD4E8D927DA343 /* NSInvocation+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 59EC97BFB024F93873949013ACFCB23D /* NSInvocation+OCMAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		CE6A4A4415CBEECD9B0802185C831AEC /* SPTExampleGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = E4699799B8F7E4ADDB0CC1B364CC5747 /* SPTExampleGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CEFF91E9F4DD710993A749CA0C53E326 /* SEGAnalyticsUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = C820D4A114952B71E8DA34CE50162D5A /* SEGAnalyticsUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CF6DE4AD8CA4138A9E0DD07EACECBE38 /* SPTSharedExampleGroups.h in Headers */ = {isa = PBXBuildFile; fileRef = 860B2E29A2F03787759B21D4B7D7765F /* SPTSharedExampleGroups.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D01FD5CA614A9B2C2C004F998A97B8E5 /* OCMNonRetainingObjectReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 7583DF54BEB576D97684BF5AD63EB1E4 /* OCMNonRetainingObjectReturnValueProvider.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		D07635EFD68CFD3ECB3E38569BCE6F4A /* SEGAliasPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = F064E29934683EA840450B31EF1279B3 /* SEGAliasPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D09E0FCBA427032EF3C6603618615DEA /* SEGFileStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = A953E713899B72D2C15FC4DF168CD115 /* SEGFileStorage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D0F28A394E5CDC4EB3167894D88C579F /* FBSnapshotTestCasePlatform.h in Headers */ = {isa = PBXBuildFile; fileRef = D32F418D184BC8A122AB17CF79DB7F7A /* FBSnapshotTestCasePlatform.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D1B7EFFA5C21C6C6351689B841B348E7 /* SEGAnalytics.h in Headers */ = {isa = PBXBuildFile; fileRef = F24FB3D905866F113C184B959133399B /* SEGAnalytics.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D22B019FA8B204DBA269344C6A9B7AB4 /* EXPMatchers+raiseWithReason.h in Headers */ = {isa = PBXBuildFile; fileRef = 60E3C4F1A8930529085D1F892246D85A /* EXPMatchers+raiseWithReason.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D36B76B7B44977187A238206311429F0 /* OCMock-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = C8E18538FA64F773053BD0C177BACC13 /* OCMock-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D3C846F8E884515E1C43F10049698B6A /* EXPMatchers+haveCountOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A9F8407215E4D8AC8E6E6F0C0FEF719 /* EXPMatchers+haveCountOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		D4E99BE630A41E4E16C8510E7C858CC0 /* OCMIndirectReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 940B5B083475CC5DE8945708096FDAA0 /* OCMIndirectReturnValueProvider.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		D5A3BE26D04FAA353D345C8B2BD5355E /* OCMBoxedReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 8FCE2016699722CEC2AB6D95EB90707A /* OCMBoxedReturnValueProvider.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		D70A4864E756F0908A7D7D4CEDDC298D /* Specta.h in Headers */ = {isa = PBXBuildFile; fileRef = 51B8CAB25EDB0C9EC599C062026D5652 /* Specta.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D79686F85ABF915F76F0FC2833B946CD /* OCMBlockCaller.m in Sources */ = {isa = PBXBuildFile; fileRef = 01A886871970EAF92E332FFBE790E3B0 /* OCMBlockCaller.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		D85E320243F6214C3B3396497AC1168A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6FD9D030738482969FA185B5402D2F8D /* Foundation.framework */; };
-		D901773AF07AAC5235D25134E2D887CD /* AvoUnknownType.m in Sources */ = {isa = PBXBuildFile; fileRef = 038D6C236EA84CB213BFA90D9AD16A81 /* AvoUnknownType.m */; };
+		D923FCA29609D01B0CAB584D443842A8 /* FBSnapshotTestCase-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = F6349CB56C9BE5592A69B056A5E70E5A /* FBSnapshotTestCase-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D9FF6D07C489BD9D91808CCB8B32A295 /* OCMBoxedReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 09B875016898AACF6E31FF26EF4C936F /* OCMBoxedReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		DA1D01E35623C4C8EAC266A4D3D2285A /* AvoEventSpecCache.h in Headers */ = {isa = PBXBuildFile; fileRef = D2B0A62A430CB996421976D614FE9F47 /* AvoEventSpecCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DB70381670469AB249C2D698304A4008 /* SEGStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 326F892C44E3B372D2FB1C9017991891 /* SEGStorage.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DBE8B19390B05FC3F3A913317CE72967 /* NSValue+Expecta.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F9F642AC01805479229379C0A3DEC42 /* NSValue+Expecta.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		DC1D0A9D6FC52B36592547F41D779EE0 /* EXPMatchers+beGreaterThan.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B1C8E49866C1A7400FF289BD690C869 /* EXPMatchers+beGreaterThan.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DCA8BF4AD6B5FEDED3F59A41BC04813E /* EXPMatchers+beGreaterThanOrEqualTo.m in Sources */ = {isa = PBXBuildFile; fileRef = EE563C277281A6C72B5F76026D19F921 /* EXPMatchers+beGreaterThanOrEqualTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		DCC00F6470D24363047ED63F62C375E0 /* AvoInspector.h in Headers */ = {isa = PBXBuildFile; fileRef = 578C3CBB97F8DD56F18223700EFA7DE0 /* AvoInspector.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DEBB05AD9A1F37CF36AAABC447EEA2BD /* OCPartialMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = ED1031AEE0C24D29CC0371B0D180C3CD /* OCPartialMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		DF21A7599DC9A1C08851EB8432A7A536 /* OCMExceptionReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = A73507CE7F6904EC381D839FFD87CB8A /* OCMExceptionReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		DF306AC3190293225FDC28F90A3F55D2 /* OCMVerifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 2AE6D4B291EFBEB27C34D81E2F2CC993 /* OCMVerifier.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -287,132 +290,131 @@
 		E13558077FE399AAD3E2F6DE1B76F7FF /* EXPMatchers+beSupersetOf.m in Sources */ = {isa = PBXBuildFile; fileRef = BF99F873584873D3483C036AF27199BA /* EXPMatchers+beSupersetOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		E14C92DE9E1C5F39773DF5D5732E4F77 /* EXPMatchers+beLessThan.h in Headers */ = {isa = PBXBuildFile; fileRef = 353D22D39E8763F720A12D325C85F196 /* EXPMatchers+beLessThan.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E1A6355032C25C8A94CD54B2AA122169 /* SEGUserDefaultsStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E409D8A54DA609956B09D19ED480976 /* SEGUserDefaultsStorage.m */; };
+		E318FBE2E27689B23DA771B8B0520CFB /* SPTExampleGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B554258FF17C502915BCE79344087DD /* SPTExampleGroup.m */; };
 		E3DACFAF45457ACF68ECD29F9861ADA8 /* EXPMatchers+haveCountOf.h in Headers */ = {isa = PBXBuildFile; fileRef = D61DAA7C76FDC961C4E0993549C15B11 /* EXPMatchers+haveCountOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E525AADDECBB8CD91F5019755DAB9212 /* EXPMatchers+conformTo.m in Sources */ = {isa = PBXBuildFile; fileRef = FBB018F530B93A9ED2C74DE720CA21A8 /* EXPMatchers+conformTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		E5E27481216D20B0057D1863509ED095 /* OCMConstraint.h in Headers */ = {isa = PBXBuildFile; fileRef = 29DFD5100D263B66F0C11A62486BA0AA /* OCMConstraint.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E7ECFB4B7F9F5E9B918211100D5FF688 /* Specta-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 7103C493E7D2C94D5B260BD3BFA9C521 /* Specta-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E81124577DAD63106202A5DBDFFED611 /* NSObject+Expecta.h in Headers */ = {isa = PBXBuildFile; fileRef = C3C48197D5DBA9C81B3C385DE9FF6573 /* NSObject+Expecta.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E86191783F85F75C1A02497CBA8BC0A1 /* EXPMatchers+equal.h in Headers */ = {isa = PBXBuildFile; fileRef = 82CD04DCED3AE73CB2D01652C30B4811 /* EXPMatchers+equal.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E9293655B198D6D1B8D79C7C11C4F4CD /* SEGTrackPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B0AD33E190C33729F51E0C2F384ABDF /* SEGTrackPayload.m */; };
-		E95D020AD4A525AA413772AC2D49031D /* AvoDeduplicator.m in Sources */ = {isa = PBXBuildFile; fileRef = E1E2556DB4880FEA7020412FFB9670A1 /* AvoDeduplicator.m */; };
 		EA19961E4C1BC57CC6A74CD7B05D650B /* OCMRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AF8C05ACD2847FB70A8FBE0EC6D09CD /* OCMRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		EAB5581053569E8B561BCD5B0B218D66 /* OCMBlockArgCaller.h in Headers */ = {isa = PBXBuildFile; fileRef = B180DE978EFDC49034AF1F2263406B33 /* OCMBlockArgCaller.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		EC1F0445B4E9A345D6A6339AD26B107A /* AvoString.m in Sources */ = {isa = PBXBuildFile; fileRef = 3ABA70C68A06163DB0CD69AC993324F9 /* AvoString.m */; };
-		EC85FC77E03DB3D8F30933360F3ED06B /* Inspector.h in Headers */ = {isa = PBXBuildFile; fileRef = ABCF0D077978AAB841F0BBA3F30ED727 /* Inspector.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		ED3119D15C7377DE48D0AC2D9D3069FA /* SPTExcludeGlobalBeforeAfterEach.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FD96D6BCA96E12AF1CC59350536E18F /* SPTExcludeGlobalBeforeAfterEach.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ED5BDC6CC5E5F21AA4CBFA4C642AEA12 /* AvoBoolean.h in Headers */ = {isa = PBXBuildFile; fileRef = 26741524D48E0D50E4330AF36CD60097 /* AvoBoolean.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ED69C5A854EEB2ADA94F41397CBF5EAE /* NSObject+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = F5AF64F2FAA9B10E1B6B37AAE4E7A66F /* NSObject+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		EE14AE296FD03A33D7CD637C953C36CF /* OCMInvocationExpectation.h in Headers */ = {isa = PBXBuildFile; fileRef = DBDDB7AF3CE40181BC4B60797480BD61 /* OCMInvocationExpectation.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		EE86E9C4FA7688EF882A937BBF5040EB /* SEGUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = FD2EE004EC3EF6EC7CC50213F9215993 /* SEGUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		EEA09BA7827B978EC01A8A24F73137FC /* Specta-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = EC9C902129ADABE5DEF960D3A70EA3E4 /* Specta-dummy.m */; };
 		EEAEC6C1D8FC730761CAC170E17216F9 /* NSData+SEGGZIP.h in Headers */ = {isa = PBXBuildFile; fileRef = E7C0CCA7DF2FBE1A6E77E1929A88838A /* NSData+SEGGZIP.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EEF975FF4A1C7534532877EDE56C68CE /* ExpectaObject+FBSnapshotTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 94A5D04C74141BDB47E9AA8E4CB68535 /* ExpectaObject+FBSnapshotTest.m */; };
 		EF04F010E0E3700CD1D9F8507685704B /* OCMIndirectReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 22A23A86869C7D513638ABF0D0BA963D /* OCMIndirectReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		EF9DDC7DCDBC74A412C7C894A334B762 /* NSValue+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = B5024D6273F5A704A0A131AD1F2D6013 /* NSValue+OCMAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		F05516502B0EF2C395D3ABAF16AA5587 /* SPTSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = D85836D70C6ECFA262C7EEF374490F99 /* SPTSpec.m */; };
+		F05F1B346679EFADA14BF111F0C0E9E9 /* SPTCallSite.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C69E935EFB0CFB33829ECAA85BB435E /* SPTCallSite.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F0E1AE4D6053107DC0CC6D2E753BA4DC /* AvoEventSchemaType.h in Headers */ = {isa = PBXBuildFile; fileRef = 790F5219355A902DED1E675EADFC01D8 /* AvoEventSchemaType.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F1370A0DB019FCDCE0077D1E64B549A2 /* EXPMatchers+beSubclassOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 92E063AEC0C1D2F181AB2D61DA3D63C2 /* EXPMatchers+beSubclassOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		F171A0C5005839606EB18432A356383E /* Pods-AvoStateOfTracking_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 6D98178C3E3CCBE38853833D09B82C9D /* Pods-AvoStateOfTracking_Tests-dummy.m */; };
+		F1F05CD4858A27EA49278F554AA00CBD /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 0C25C5555B918DA65963EBD41EF2550F /* PrivacyInfo.xcprivacy */; };
 		F5A8ED8D58C6661B73BC5A45086700AE /* OCMFunctionsPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AEC7F15ABC96C5A4254DCE00D7D9440 /* OCMFunctionsPrivate.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		F7A5A517F200011A95C99F6D97672277 /* AvoDeduplicator.h in Headers */ = {isa = PBXBuildFile; fileRef = BFF320C496B06A51EE9AF62FD9F939BF /* AvoDeduplicator.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F796EC4896C454D173A105FE87F99819 /* SPTExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 37921A99413848068D682A7EDC14C84C /* SPTExample.m */; };
 		F7B02323552BA4E5F80E075332626028 /* OCMStubRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = B648F0E33A09B1C85DD9AF56CDE61DE9 /* OCMStubRecorder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F7DC2FC45F91CF648D885B248035A419 /* NSValue+Expecta.h in Headers */ = {isa = PBXBuildFile; fileRef = F9E6666EB39D806594114E9C34DA3895 /* NSValue+Expecta.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F8B32A34F7FD111CCC0F65220FC2761C /* EXPDoubleTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = 12CEC85107BB5342BD12B86B9299C63B /* EXPDoubleTuple.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		F90B38F219C25D02A0F4F89A69272910 /* Expecta+Snapshots-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 02BFF5915854C4AD367E9DE963D7DAD5 /* Expecta+Snapshots-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F98ED7688ECEBA58477D1AE4D01C04A2 /* Expecta-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A7E40F96297E3787C72C2C31FC3F3ED8 /* Expecta-dummy.m */; };
 		F9B11A84D8AF6B6C71CB2CBB34B3883D /* EXPDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 9FE96EA2314E98B7954A519F5FDD82A9 /* EXPDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FA77FA431CDFE32702DF32E2A5CF4A64 /* SPTSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = 93E281E64A60B7EE7E1915D8F0BA8D0F /* SPTSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FA7F793719AA7D6E40414E3ECD2E74FD /* UIApplication+StrictKeyWindow.h in Headers */ = {isa = PBXBuildFile; fileRef = 19E84F6CA58959C8A74659B791DA68B9 /* UIApplication+StrictKeyWindow.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		FAAC27EA05C515D2190DAC4536FEB58F /* OCMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = C0F2DA277944461CD09092641F36E6BE /* OCMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		FB7895E3A17915DDEDB4A14E01398F5D /* SPTExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 37921A99413848068D682A7EDC14C84C /* SPTExample.m */; };
 		FC10AE60B73949F45902C2133EBDB02E /* EXPExpect.m in Sources */ = {isa = PBXBuildFile; fileRef = B03394A10FDC608BF1B787666A1AB2CB /* EXPExpect.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		FC688D898A1D280DCF2147D9570BC6D3 /* UIViewController+SEGScreen.h in Headers */ = {isa = PBXBuildFile; fileRef = 93880751CDEE03AAB0E2EFF1286F9A6E /* UIViewController+SEGScreen.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FDC9C7C3BA26AB839EA90759E0F66CB7 /* SPTCompiledExample.h in Headers */ = {isa = PBXBuildFile; fileRef = 2519B384F889E623BEB7B81246BC4C16 /* SPTCompiledExample.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FDF8E3226F04116D241D025724F095D7 /* SEGContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E25982BAD03A1224121B20F0BCBCA64 /* SEGContext.m */; };
 		FEA9DB987E23C72F6DF151BEA5425254 /* OCMStubRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B535E619DDF4596EFA485D59AE80C6B /* OCMStubRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		FF21BD6FE3D52EF4015615586FAD4BF8 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69F73B6C90468A4F6F6D7185C76B627E /* XCTest.framework */; };
-		FF61B28C3A64788818AE97C6C4D08B10 /* AvoEventValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F2597E1BF960E93C626856E681C6926 /* AvoEventValidator.m */; };
+		FFB7AD928D101647F76080BC6D0DCB5A /* AvoEventSpecFetcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B6952669D99AC3C1505393E9E81F91E /* AvoEventSpecFetcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		00808B01EE7DF83275DF3399BAEEA12A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 86C2B19C6C53B2E2160EC2BD12330652;
-			remoteInfo = "Pods-AvoStateOfTracking_Example";
-		};
-		1AC572E97818FF481DA6725F12F7008E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = DC371B7477C88184274EC6710690F97C;
-			remoteInfo = Expecta;
-		};
-		389541FE29DF6C0C1149AC8F8FF25E2E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = DC371B7477C88184274EC6710690F97C;
-			remoteInfo = Expecta;
-		};
-		3E9A2EB1B5E93C2B47BBCA3551FCD3DA /* PBXContainerItemProxy */ = {
+		324C53BB8D0D250C965FC16D718D7F5A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = C260B5A26D3CD54F215E5E39371483B6;
 			remoteInfo = OCMock;
 		};
-		6BFAEBF2637C75442D1DDA7813D5FFE9 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = F8676010755CF1530FC02DA9A0D8822B;
-			remoteInfo = Specta;
-		};
-		A835733CA7530D2635CFE2137A7FB995 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = F8676010755CF1530FC02DA9A0D8822B;
-			remoteInfo = Specta;
-		};
-		D03EFB714C7897CB276D5EC20F8168EE /* PBXContainerItemProxy */ = {
+		33A4F7182E49B8901354F2654389DBD4 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 98A98149697C80CEF8D5772791E92E66;
 			remoteInfo = FBSnapshotTestCase;
 		};
-		D50B7299F7AC0BEBD8B655539EEB9F33 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = F4C762008BED3853BA2FF0F9CF0C3D6D;
-			remoteInfo = "AvoInspector-AvoInspector";
-		};
-		E10B67E9F433077F1764A0C504738D79 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 8B98F09738742E4D780D1B20B468CD95;
-			remoteInfo = "Expecta+Snapshots";
-		};
-		E53B50D5853CF53D71A80D338CB3089D /* PBXContainerItemProxy */ = {
+		431C16FD96521BED2A7A92D664B63A01 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 8F50A15C556FFEAD343B69C7EA54092F;
 			remoteInfo = Analytics;
 		};
-		E6827F8C7CDD9EE68E016AE7E32670BB /* PBXContainerItemProxy */ = {
+		463F9C49F2789DBE7109DF348220B48A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8B98F09738742E4D780D1B20B468CD95;
+			remoteInfo = "Expecta+Snapshots";
+		};
+		59A1C12C5FE08F979B0DFAEFC26C59C2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F8676010755CF1530FC02DA9A0D8822B;
+			remoteInfo = Specta;
+		};
+		690624458642502682B8AF217334AE3A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DC371B7477C88184274EC6710690F97C;
+			remoteInfo = Expecta;
+		};
+		7A4C36E5435C17F10581A3133FAB8247 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F8676010755CF1530FC02DA9A0D8822B;
+			remoteInfo = Specta;
+		};
+		90B90D9DF8853E983E8B4E4EE56E47A0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F4C762008BED3853BA2FF0F9CF0C3D6D;
+			remoteInfo = "AvoInspector-AvoInspector";
+		};
+		A1C7779D9AFA026418507BFB762851E9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DC371B7477C88184274EC6710690F97C;
+			remoteInfo = Expecta;
+		};
+		A260D3270D096D6DA905AA3AC3748F18 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 98A98149697C80CEF8D5772791E92E66;
 			remoteInfo = FBSnapshotTestCase;
 		};
-		EC70DC9235779D02B879B7CC247EE485 /* PBXContainerItemProxy */ = {
+		BA40114A2E6A04FF15C5DC99242D4977 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 5CB07DC335904D6A8475653674C0BF14;
 			remoteInfo = AvoInspector;
+		};
+		EE96AE4792E0FF2D925ED992DF2B1063 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 86C2B19C6C53B2E2160EC2BD12330652;
+			remoteInfo = "Pods-AvoStateOfTracking_Example";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -423,8 +425,6 @@
 		01DECC33DA845C7DEB5E732B3EF451F0 /* Expecta+Snapshots-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Expecta+Snapshots-Info.plist"; sourceTree = "<group>"; };
 		0252F66741379540C7133A882F9C564C /* Expecta-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Expecta-Info.plist"; sourceTree = "<group>"; };
 		02BFF5915854C4AD367E9DE963D7DAD5 /* Expecta+Snapshots-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Expecta+Snapshots-umbrella.h"; sourceTree = "<group>"; };
-		02E4E3B41C978135D4585CC4BF112F7B /* AvoBoolean.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = AvoBoolean.h; sourceTree = "<group>"; };
-		038D6C236EA84CB213BFA90D9AD16A81 /* AvoUnknownType.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = AvoUnknownType.m; sourceTree = "<group>"; };
 		04F6B0B6A4201AA64DB0854D4F1CA1BB /* Analytics-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Analytics-umbrella.h"; sourceTree = "<group>"; };
 		056502C2EBAC383B525AF2DC29555563 /* SEGContext.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGContext.h; path = Analytics/Classes/Middlewares/SEGContext.h; sourceTree = "<group>"; };
 		05BD759B36050756E0A1DCCE831242BC /* SEGIntegrationFactory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGIntegrationFactory.h; path = Analytics/Classes/Integrations/SEGIntegrationFactory.h; sourceTree = "<group>"; };
@@ -437,20 +437,16 @@
 		09B875016898AACF6E31FF26EF4C936F /* OCMBoxedReturnValueProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMBoxedReturnValueProvider.m; path = Source/OCMock/OCMBoxedReturnValueProvider.m; sourceTree = "<group>"; };
 		0B00E5B7D40875EAF87C24822A1A16EF /* Pods-AvoStateOfTracking_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-AvoStateOfTracking_Example-frameworks.sh"; sourceTree = "<group>"; };
 		0B554258FF17C502915BCE79344087DD /* SPTExampleGroup.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTExampleGroup.m; path = Specta/Specta/SPTExampleGroup.m; sourceTree = "<group>"; };
-		0C743BD8948F4C76B052292B1D33ED6F /* AvoEventValidator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AvoEventValidator.h; path = AvoInspector/Classes/AvoEventValidator.h; sourceTree = "<group>"; };
+		0C25C5555B918DA65963EBD41EF2550F /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = AvoInspector/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		0E3F1168FB038BF6F34EBD05E76B1FF0 /* OCMExceptionReturnValueProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMExceptionReturnValueProvider.h; path = Source/OCMock/OCMExceptionReturnValueProvider.h; sourceTree = "<group>"; };
 		0E409D8A54DA609956B09D19ED480976 /* SEGUserDefaultsStorage.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGUserDefaultsStorage.m; path = Analytics/Classes/Internal/SEGUserDefaultsStorage.m; sourceTree = "<group>"; };
-		0E782B26D2EF872071701465F10F46A8 /* AvoStorage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AvoStorage.h; path = AvoInspector/Classes/AvoStorage.h; sourceTree = "<group>"; };
 		0F356EBD6FE4A50892B28F377EAA339B /* EXPMatchers+equal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+equal.m"; path = "Expecta/Matchers/EXPMatchers+equal.m"; sourceTree = "<group>"; };
 		10A931283DA69FEBA2300090B183FF45 /* OCMock-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "OCMock-prefix.pch"; sourceTree = "<group>"; };
 		113B2CAE98B17CD72E794713875778DD /* SEGGroupPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGGroupPayload.m; path = Analytics/Classes/Integrations/SEGGroupPayload.m; sourceTree = "<group>"; };
 		1143669D433AB56E303E508BD7217746 /* SpectaTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SpectaTypes.h; path = Specta/Specta/SpectaTypes.h; sourceTree = "<group>"; };
 		11B0383C6B04CAF519A3D2E82E34D559 /* AvoInspector */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = AvoInspector; path = AvoInspector.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		11E61668DA3D1777A073E4401EC884A9 /* AvoEventSpecFetcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AvoEventSpecFetcher.m; path = AvoInspector/Classes/AvoEventSpecFetcher.m; sourceTree = "<group>"; };
 		12CEC85107BB5342BD12B86B9299C63B /* EXPDoubleTuple.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPDoubleTuple.m; path = Expecta/EXPDoubleTuple.m; sourceTree = "<group>"; };
-		14CCB198FEB5532679FF53BA56912589 /* AvoList.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = AvoList.h; sourceTree = "<group>"; };
 		15B13B063AA97C48C9010C298AECBDDA /* Specta */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Specta; path = Specta.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		15E6B1A5201E540D50D44A8EA6814764 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
 		15EA70C682EAEB6BD2F3FA28CCCD9B25 /* UIImage+Compare.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImage+Compare.m"; path = "FBSnapshotTestCase/Categories/UIImage+Compare.m"; sourceTree = "<group>"; };
 		177D254CC0B34EE140561EC6EFAA80F0 /* EXPMatchers+beginWith.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beginWith.m"; path = "Expecta/Matchers/EXPMatchers+beginWith.m"; sourceTree = "<group>"; };
 		17D3D0F97BB1112CF1FBC63FB9AE0A0C /* Analytics-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Analytics-prefix.pch"; sourceTree = "<group>"; };
@@ -459,34 +455,41 @@
 		19E84F6CA58959C8A74659B791DA68B9 /* UIApplication+StrictKeyWindow.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIApplication+StrictKeyWindow.h"; path = "FBSnapshotTestCase/Categories/UIApplication+StrictKeyWindow.h"; sourceTree = "<group>"; };
 		1A708EA09DAC05037BD25E8ED8CB4448 /* Pods-AvoStateOfTracking_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-AvoStateOfTracking_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		1AA095C4CADEA623FEF5A96FEA61F4E6 /* EXPBlockDefinedMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPBlockDefinedMatcher.h; path = Expecta/EXPBlockDefinedMatcher.h; sourceTree = "<group>"; };
-		1AAD8ECBAF0BA9FA35ECFBB212D21ACF /* AvoEventSpecFetchTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AvoEventSpecFetchTypes.h; path = AvoInspector/Classes/AvoEventSpecFetchTypes.h; sourceTree = "<group>"; };
 		1AAF47C1B5566006F28567349B8383AB /* XCTest+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "XCTest+Private.h"; path = "Specta/Specta/XCTest+Private.h"; sourceTree = "<group>"; };
 		1ACB02AA0155EB39A45A8C14B6ACEB6A /* EXPMatchers+endWith.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+endWith.m"; path = "Expecta/Matchers/EXPMatchers+endWith.m"; sourceTree = "<group>"; };
+		1B074C672344ACE03111514BD1434E42 /* AvoDeduplicator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AvoDeduplicator.m; path = AvoInspector/Classes/AvoDeduplicator.m; sourceTree = "<group>"; };
 		1B282687FD6C38489582A5693ADE2B16 /* Specta.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Specta.modulemap; sourceTree = "<group>"; };
 		1B9EDABC57F952D4FE467F70928FAFD6 /* OCMVerifier.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMVerifier.m; path = Source/OCMock/OCMVerifier.m; sourceTree = "<group>"; };
 		1C3A3962788405C1AA7E4E6C040C5CBF /* EXPMatchers+beTruthy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beTruthy.h"; path = "Expecta/Matchers/EXPMatchers+beTruthy.h"; sourceTree = "<group>"; };
 		1E25982BAD03A1224121B20F0BCBCA64 /* SEGContext.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGContext.m; path = Analytics/Classes/Middlewares/SEGContext.m; sourceTree = "<group>"; };
 		1F0D75107EE9C5C5273A5BA6F6E5F618 /* FBSnapshotTestCase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FBSnapshotTestCase.h; path = FBSnapshotTestCase/FBSnapshotTestCase.h; sourceTree = "<group>"; };
 		1F1BE4636571A539C87EFB0C3AB1C90E /* OCMRecorder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMRecorder.h; path = Source/OCMock/OCMRecorder.h; sourceTree = "<group>"; };
-		203A5D32352BD7C0791FD153F5930FE8 /* AvoInspector-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AvoInspector-umbrella.h"; sourceTree = "<group>"; };
+		1FEDD12D0E95E06CDA3A818F48C93AE6 /* AvoFloat.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = AvoFloat.h; sourceTree = "<group>"; };
+		1FFBEE081D2873A076F7BC3DFD9593AE /* AvoSchemaExtractor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AvoSchemaExtractor.h; path = AvoInspector/Classes/AvoSchemaExtractor.h; sourceTree = "<group>"; };
 		20B68C9269B45825E82F4F5ECE0EB27C /* Expecta+Snapshots */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = "Expecta+Snapshots"; path = Expecta_Snapshots.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		20D6FCC49D0C393926D9075D663628B6 /* AvoNull.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = AvoNull.m; sourceTree = "<group>"; };
 		211AC8777EAC8F6EF904221191957846 /* SpectaDSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SpectaDSL.m; path = Specta/Specta/SpectaDSL.m; sourceTree = "<group>"; };
 		213E978CBCC02F496BF12EED791A7EF1 /* ExpectaSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ExpectaSupport.m; path = Expecta/ExpectaSupport.m; sourceTree = "<group>"; };
 		22A23A86869C7D513638ABF0D0BA963D /* OCMIndirectReturnValueProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMIndirectReturnValueProvider.m; path = Source/OCMock/OCMIndirectReturnValueProvider.m; sourceTree = "<group>"; };
+		2399E226A9877FA4E9CA3119E64790CF /* AvoEventSpecFetcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AvoEventSpecFetcher.m; path = AvoInspector/Classes/AvoEventSpecFetcher.m; sourceTree = "<group>"; };
 		23B0F429FEE76D8326C7F2F8F878C9B7 /* EXPMatchers+raise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+raise.h"; path = "Expecta/Matchers/EXPMatchers+raise.h"; sourceTree = "<group>"; };
 		23EB41B7AFCF53C0DB0E9AD98B2DDC03 /* Pods-AvoStateOfTracking_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-AvoStateOfTracking_Example.modulemap"; sourceTree = "<group>"; };
 		2519B384F889E623BEB7B81246BC4C16 /* SPTCompiledExample.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTCompiledExample.h; path = Specta/Specta/SPTCompiledExample.h; sourceTree = "<group>"; };
 		25C39B0CB6DBA1AA05A773890F51C760 /* EXPMatchers+beNil.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beNil.h"; path = "Expecta/Matchers/EXPMatchers+beNil.h"; sourceTree = "<group>"; };
 		263A8F0A5DF172C5569DAA8827BE88C9 /* OCMObserverRecorder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMObserverRecorder.h; path = Source/OCMock/OCMObserverRecorder.h; sourceTree = "<group>"; };
+		26741524D48E0D50E4330AF36CD60097 /* AvoBoolean.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = AvoBoolean.h; sourceTree = "<group>"; };
 		287516F366A409A3E64F4F7CC6F01D07 /* OCMQuantifier.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMQuantifier.h; path = Source/OCMock/OCMQuantifier.h; sourceTree = "<group>"; };
 		28CE5540FC5B22AB910784C7E20153BA /* SEGIdentifyPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGIdentifyPayload.m; path = Analytics/Classes/Integrations/SEGIdentifyPayload.m; sourceTree = "<group>"; };
 		29DFD5100D263B66F0C11A62486BA0AA /* OCMConstraint.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMConstraint.h; path = Source/OCMock/OCMConstraint.h; sourceTree = "<group>"; };
 		2AAC25E011D77CB3D4BB4BF082EA87C7 /* OCMNonRetainingObjectReturnValueProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMNonRetainingObjectReturnValueProvider.m; path = Source/OCMock/OCMNonRetainingObjectReturnValueProvider.m; sourceTree = "<group>"; };
 		2AE6D4B291EFBEB27C34D81E2F2CC993 /* OCMVerifier.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMVerifier.h; path = Source/OCMock/OCMVerifier.h; sourceTree = "<group>"; };
 		2CE4B6165F426953A26419DF02AF0D93 /* Analytics */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Analytics; path = Analytics.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2D00522674DC08BC7BE6DC6822ED1E5F /* AvoSchemaExtractor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AvoSchemaExtractor.m; path = AvoInspector/Classes/AvoSchemaExtractor.m; sourceTree = "<group>"; };
 		2D43C69422329C9A2615E85C82A44D83 /* EXPMatchers+match.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+match.h"; path = "Expecta/Matchers/EXPMatchers+match.h"; sourceTree = "<group>"; };
+		2D6EF0EBCD80431119543F461AED41A1 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
 		2D8E0D400C92D7AC033A4D4311E48516 /* SEGSegmentIntegration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGSegmentIntegration.m; path = Analytics/Classes/Internal/SEGSegmentIntegration.m; sourceTree = "<group>"; };
+		2E0378F169A2652F65528D95369711E5 /* AvoFloat.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = AvoFloat.m; sourceTree = "<group>"; };
+		2E1EB07A2558B365D82EC9A5DE4CE430 /* AvoStorage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AvoStorage.h; path = AvoInspector/Classes/AvoStorage.h; sourceTree = "<group>"; };
+		2F62F3ABCD572CA0A4B9F6D4478EE3D5 /* AvoInspector-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AvoInspector-Info.plist"; sourceTree = "<group>"; };
 		2FC746F476003FE8DC5DA182C69F45B5 /* OCMock.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = OCMock.modulemap; sourceTree = "<group>"; };
 		2FD96D6BCA96E12AF1CC59350536E18F /* SPTExcludeGlobalBeforeAfterEach.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTExcludeGlobalBeforeAfterEach.h; path = Specta/Specta/SPTExcludeGlobalBeforeAfterEach.h; sourceTree = "<group>"; };
 		3123BAC06AA368AF8E453A6257DF1F81 /* NSValue+OCMAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValue+OCMAdditions.m"; path = "Source/OCMock/NSValue+OCMAdditions.m"; sourceTree = "<group>"; };
@@ -497,18 +500,18 @@
 		32F6C9761C5EBF1FD1E2E806B73ECFC1 /* SPTCompiledExample.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTCompiledExample.m; path = Specta/Specta/SPTCompiledExample.m; sourceTree = "<group>"; };
 		34B9F5D2B054D1C634C2FBAAC2E4D030 /* OCMObjectReturnValueProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMObjectReturnValueProvider.h; path = Source/OCMock/OCMObjectReturnValueProvider.h; sourceTree = "<group>"; };
 		353D22D39E8763F720A12D325C85F196 /* EXPMatchers+beLessThan.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beLessThan.h"; path = "Expecta/Matchers/EXPMatchers+beLessThan.h"; sourceTree = "<group>"; };
-		3741DA3456746B34C0C805196EEB5725 /* AvoInspector.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AvoInspector.release.xcconfig; sourceTree = "<group>"; };
 		37921A99413848068D682A7EDC14C84C /* SPTExample.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTExample.m; path = Specta/Specta/SPTExample.m; sourceTree = "<group>"; };
-		38E7D075617A98BFF1264F9557387DBD /* AvoSchemaExtractor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AvoSchemaExtractor.m; path = AvoInspector/Classes/AvoSchemaExtractor.m; sourceTree = "<group>"; };
+		379BA466768D48F013EE1EA03D708DB2 /* AvoEventSpecCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AvoEventSpecCache.m; path = AvoInspector/Classes/AvoEventSpecCache.m; sourceTree = "<group>"; };
 		390AC0A95284C24AE2EC56A8F037352B /* UIImage+Diff.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImage+Diff.m"; path = "FBSnapshotTestCase/Categories/UIImage+Diff.m"; sourceTree = "<group>"; };
 		392DB5E6D4CCAEFC74C9DFE101137330 /* OCMInvocationExpectation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMInvocationExpectation.m; path = Source/OCMock/OCMInvocationExpectation.m; sourceTree = "<group>"; };
 		39A58F2F671771EE0C83E7F0ABF08DD7 /* OCProtocolMockObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCProtocolMockObject.m; path = Source/OCMock/OCProtocolMockObject.m; sourceTree = "<group>"; };
+		39D40952AB64E5374262554E98BE6A6F /* AvoEventSchemaType.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = AvoEventSchemaType.m; sourceTree = "<group>"; };
 		3A9F8407215E4D8AC8E6E6F0C0FEF719 /* EXPMatchers+haveCountOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+haveCountOf.m"; path = "Expecta/Matchers/EXPMatchers+haveCountOf.m"; sourceTree = "<group>"; };
-		3ABA70C68A06163DB0CD69AC993324F9 /* AvoString.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = AvoString.m; sourceTree = "<group>"; };
 		3AE115DD92E26A790115FED62FF0D3CD /* NSInvocation+OCMAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSInvocation+OCMAdditions.m"; path = "Source/OCMock/NSInvocation+OCMAdditions.m"; sourceTree = "<group>"; };
 		3AEC7F15ABC96C5A4254DCE00D7D9440 /* OCMFunctionsPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMFunctionsPrivate.h; path = Source/OCMock/OCMFunctionsPrivate.h; sourceTree = "<group>"; };
 		3AF8C05ACD2847FB70A8FBE0EC6D09CD /* OCMRecorder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMRecorder.m; path = Source/OCMock/OCMRecorder.m; sourceTree = "<group>"; };
-		3DA2A8E2329A2740C7293ED9D413102C /* AvoInspector.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AvoInspector.m; path = AvoInspector/Classes/AvoInspector.m; sourceTree = "<group>"; };
+		3B6A9A5E885251E18289D77441F99C23 /* AvoNull.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = AvoNull.m; sourceTree = "<group>"; };
+		3BDD30A1C84B7DA2C3E27B7A6B6CCEB5 /* AvoInspector-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AvoInspector-prefix.pch"; sourceTree = "<group>"; };
 		3E297C6EAFD444E2920F2A5E1CF49BC2 /* OCMBlockArgCaller.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMBlockArgCaller.m; path = Source/OCMock/OCMBlockArgCaller.m; sourceTree = "<group>"; };
 		3EA4B91F5A0E0BCCC7DAB9112549BE3C /* SEGUserDefaultsStorage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGUserDefaultsStorage.h; path = Analytics/Classes/Internal/SEGUserDefaultsStorage.h; sourceTree = "<group>"; };
 		3F77461A7ADDB8C1872D237D2404A12A /* SEGPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGPayload.m; path = Analytics/Classes/Integrations/SEGPayload.m; sourceTree = "<group>"; };
@@ -522,19 +525,18 @@
 		45625B4E4291B0BD9E3483058B31D11C /* OCMInvocationMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMInvocationMatcher.m; path = Source/OCMock/OCMInvocationMatcher.m; sourceTree = "<group>"; };
 		45ACBDFA111EA40CE70310DB94AA9619 /* Expecta.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Expecta.modulemap; sourceTree = "<group>"; };
 		45CACC982D5641B635B19AE3F78AA37D /* ExpectaObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ExpectaObject.m; path = Expecta/ExpectaObject.m; sourceTree = "<group>"; };
-		47788E8E2C73F5264A861C41493D8238 /* AvoNull.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = AvoNull.h; sourceTree = "<group>"; };
+		47E02A6E51EC790668D4CEB2A6DEB11F /* AvoEventValidator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AvoEventValidator.m; path = AvoInspector/Classes/AvoEventValidator.m; sourceTree = "<group>"; };
 		47F1A97288EAB253DF092EAC557B66A4 /* Expecta+Snapshots.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Expecta+Snapshots.debug.xcconfig"; sourceTree = "<group>"; };
-		47F46E7E2A83F59389AB4F37443FF89A /* AvoObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = AvoObject.h; sourceTree = "<group>"; };
 		4901497783016C7F801E370251405689 /* SEGAES256Crypto.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGAES256Crypto.m; path = Analytics/Classes/Crypto/SEGAES256Crypto.m; sourceTree = "<group>"; };
 		49647D9B9EA69796980669F1E5D0EC73 /* EXPMatchers+beLessThanOrEqualTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beLessThanOrEqualTo.m"; path = "Expecta/Matchers/EXPMatchers+beLessThanOrEqualTo.m"; sourceTree = "<group>"; };
 		496E92F3AC651E5DAE3F0C6C4CB65718 /* SEGSerializableValue.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGSerializableValue.h; path = Analytics/Classes/SEGSerializableValue.h; sourceTree = "<group>"; };
 		4AC17C97422DB26268BFC89AEADBE9BA /* OCMConstraint.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMConstraint.m; path = Source/OCMock/OCMConstraint.m; sourceTree = "<group>"; };
+		4B915E7F7FECA66AF5CC22E749A71230 /* AvoObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = AvoObject.m; sourceTree = "<group>"; };
 		4CB67D39164F2836E6C58284DDA8C1E9 /* OCMNotificationPoster.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMNotificationPoster.m; path = Source/OCMock/OCMNotificationPoster.m; sourceTree = "<group>"; };
 		4D2B31F7254828169182A9E62E26C6CE /* FBSnapshotTestCasePlatform.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = FBSnapshotTestCasePlatform.m; path = FBSnapshotTestCase/FBSnapshotTestCasePlatform.m; sourceTree = "<group>"; };
 		4D6BA60AE9110C2706FDC49078E2B9C6 /* SPTGlobalBeforeAfterEach.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTGlobalBeforeAfterEach.h; path = Specta/Specta/SPTGlobalBeforeAfterEach.h; sourceTree = "<group>"; };
 		4DD14BA05613169A1E45037FB225819D /* EXPMatcherHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPMatcherHelpers.h; path = Expecta/Matchers/EXPMatcherHelpers.h; sourceTree = "<group>"; };
-		4E874ECE0A24B5C627147DA932F29C1F /* AvoString.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = AvoString.h; sourceTree = "<group>"; };
-		4F2597E1BF960E93C626856E681C6926 /* AvoEventValidator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AvoEventValidator.m; path = AvoInspector/Classes/AvoEventValidator.m; sourceTree = "<group>"; };
+		4EF29B41E096F8698DD5C733AA6699CF /* AvoList.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = AvoList.h; sourceTree = "<group>"; };
 		4F2CFB61039DEF169E7C53C30A589B18 /* EXPMatchers+contain.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+contain.h"; path = "Expecta/Matchers/EXPMatchers+contain.h"; sourceTree = "<group>"; };
 		51184837B70082873A90D7887E84DBAF /* OCMInvocationMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMInvocationMatcher.h; path = Source/OCMock/OCMInvocationMatcher.h; sourceTree = "<group>"; };
 		51B8CAB25EDB0C9EC599C062026D5652 /* Specta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Specta.h; path = Specta/Specta/Specta.h; sourceTree = "<group>"; };
@@ -544,10 +546,11 @@
 		52B484650A9CAD7F15D3D8CC26049E1C /* FBSnapshotTestController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FBSnapshotTestController.h; path = FBSnapshotTestCase/FBSnapshotTestController.h; sourceTree = "<group>"; };
 		53B732FB00D232E5F4123FC655F07E80 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
 		560F23459F36F8664C47D721CE275F03 /* EXPMatchers+contain.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+contain.m"; path = "Expecta/Matchers/EXPMatchers+contain.m"; sourceTree = "<group>"; };
-		578C3CBB97F8DD56F18223700EFA7DE0 /* AvoInspector.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AvoInspector.h; path = AvoInspector/Classes/AvoInspector.h; sourceTree = "<group>"; };
 		58749FE58FAC14C6FA5FEC67D826FC0A /* SEGSegmentIntegrationFactory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGSegmentIntegrationFactory.m; path = Analytics/Classes/Internal/SEGSegmentIntegrationFactory.m; sourceTree = "<group>"; };
+		58F22A3684E27B3119E9C19B6068EE35 /* AvoUtils.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AvoUtils.h; path = AvoInspector/Classes/AvoUtils.h; sourceTree = "<group>"; };
 		592F53BB2CD6AB34D294F5F0A52CA5F3 /* EXPMatchers+FBSnapshotTest.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "EXPMatchers+FBSnapshotTest.m"; sourceTree = "<group>"; };
 		598059DB73C78C941F3635B70589E64E /* SEGSegmentIntegrationFactory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGSegmentIntegrationFactory.h; path = Analytics/Classes/Internal/SEGSegmentIntegrationFactory.h; sourceTree = "<group>"; };
+		59B03BE100305444A2C4AA46124C532D /* AvoInspector.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AvoInspector.h; path = AvoInspector/Classes/AvoInspector.h; sourceTree = "<group>"; };
 		59CE28B702AFEC852367744DA180A7DD /* EXPUnsupportedObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPUnsupportedObject.m; path = Expecta/EXPUnsupportedObject.m; sourceTree = "<group>"; };
 		59EC97BFB024F93873949013ACFCB23D /* NSInvocation+OCMAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSInvocation+OCMAdditions.h"; path = "Source/OCMock/NSInvocation+OCMAdditions.h"; sourceTree = "<group>"; };
 		5A54659396B0B36448F048EB9492C5B5 /* SEGMiddleware.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGMiddleware.h; path = Analytics/Classes/Middlewares/SEGMiddleware.h; sourceTree = "<group>"; };
@@ -566,58 +569,60 @@
 		60821DC560B94166DF90F121F0025267 /* ExpectaSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ExpectaSupport.h; path = Expecta/ExpectaSupport.h; sourceTree = "<group>"; };
 		609FF4A527F48598E61673CD1AFAC865 /* OCMMacroState.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMMacroState.h; path = Source/OCMock/OCMMacroState.h; sourceTree = "<group>"; };
 		60E3C4F1A8930529085D1F892246D85A /* EXPMatchers+raiseWithReason.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+raiseWithReason.h"; path = "Expecta/Matchers/EXPMatchers+raiseWithReason.h"; sourceTree = "<group>"; };
-		618B007074A8ADB69E39EC1F7DF7F7B4 /* AvoSchemaExtractor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AvoSchemaExtractor.h; path = AvoInspector/Classes/AvoSchemaExtractor.h; sourceTree = "<group>"; };
 		618F94860D6C572C80DC110EBF8AEB06 /* EXPMatchers+beSubclassOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beSubclassOf.h"; path = "Expecta/Matchers/EXPMatchers+beSubclassOf.h"; sourceTree = "<group>"; };
 		623A6CBFBD914F31689348E3E9249169 /* SEGAliasPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGAliasPayload.m; path = Analytics/Classes/Integrations/SEGAliasPayload.m; sourceTree = "<group>"; };
-		62636EEA0826F8656B9FA53FE4CED721 /* AvoNetworkCallsHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AvoNetworkCallsHandler.h; path = AvoInspector/Classes/AvoNetworkCallsHandler.h; sourceTree = "<group>"; };
+		6250DFC2EA838D81BF29ECC30970D1AD /* AvoInspector.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AvoInspector.modulemap; sourceTree = "<group>"; };
 		6358F295A302A96F896A21302505ADFE /* Expecta+Snapshots.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Expecta+Snapshots.modulemap"; sourceTree = "<group>"; };
-		6586F0F76E995B08E6A6CF7B3C9EC667 /* AvoFloat.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = AvoFloat.m; sourceTree = "<group>"; };
 		66535179E85E010D20899D729CF4A0CE /* Expecta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Expecta.h; path = Expecta/Expecta.h; sourceTree = "<group>"; };
 		667C0ECC16F0AF57265EF3EAE776A4D4 /* SpectaUtility.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SpectaUtility.h; path = Specta/Specta/SpectaUtility.h; sourceTree = "<group>"; };
 		66BA3ACBF44098FEB43B8A8E712EA230 /* SEGIntegrationsManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGIntegrationsManager.m; path = Analytics/Classes/Integrations/SEGIntegrationsManager.m; sourceTree = "<group>"; };
 		67355AB3E762346A41BB551A989E28AF /* OCMLocation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMLocation.h; path = Source/OCMock/OCMLocation.h; sourceTree = "<group>"; };
 		68042FB6D430BCB325E0AF9166D32B66 /* EXPMatchers+respondTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+respondTo.m"; path = "Expecta/Matchers/EXPMatchers+respondTo.m"; sourceTree = "<group>"; };
-		699C91B5CB2674B514629B0861E1D11A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = AvoInspector/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		69F73B6C90468A4F6F6D7185C76B627E /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		6A2A5CDF6EC4159F1B93B3322DDA053E /* OCMFunctions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMFunctions.m; path = Source/OCMock/OCMFunctions.m; sourceTree = "<group>"; };
 		6AB2C4A3D340E237803DF001A5351C25 /* SEGScreenPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGScreenPayload.h; path = Analytics/Classes/Integrations/SEGScreenPayload.h; sourceTree = "<group>"; };
-		6BD7E9F680E4AF560BFC8074CB38F034 /* AvoNetworkCallsHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AvoNetworkCallsHandler.m; path = AvoInspector/Classes/AvoNetworkCallsHandler.m; sourceTree = "<group>"; };
+		6B1FE2AD6DEC12989C6C43975BDD1230 /* AvoGuid.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AvoGuid.h; path = AvoInspector/Classes/AvoGuid.h; sourceTree = "<group>"; };
+		6B6952669D99AC3C1505393E9E81F91E /* AvoEventSpecFetcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AvoEventSpecFetcher.h; path = AvoInspector/Classes/AvoEventSpecFetcher.h; sourceTree = "<group>"; };
 		6C14B8692C087275D78499799CEB73F0 /* SEGAnalyticsConfiguration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGAnalyticsConfiguration.m; path = Analytics/Classes/SEGAnalyticsConfiguration.m; sourceTree = "<group>"; };
 		6C7037CD2D1271745FCAB310773A2AD8 /* OCMFunctions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMFunctions.h; path = Source/OCMock/OCMFunctions.h; sourceTree = "<group>"; };
 		6D127215D32F3007A901315786F2AC69 /* EXPMatchers+beCloseTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beCloseTo.m"; path = "Expecta/Matchers/EXPMatchers+beCloseTo.m"; sourceTree = "<group>"; };
 		6D98178C3E3CCBE38853833D09B82C9D /* Pods-AvoStateOfTracking_Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-AvoStateOfTracking_Tests-dummy.m"; sourceTree = "<group>"; };
-		6DCDCCB631E371C4BE0D5B4020B2327A /* AvoList.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = AvoList.m; sourceTree = "<group>"; };
 		6E3788BA5416113B6C445020763C5ACE /* Analytics.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Analytics.modulemap; sourceTree = "<group>"; };
 		6E4D87795C32C491B528F6BD0B0D0A27 /* OCMObjectReturnValueProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMObjectReturnValueProvider.m; path = Source/OCMock/OCMObjectReturnValueProvider.m; sourceTree = "<group>"; };
-		6ECD35C03E8AE0C97FEC4F507D20A892 /* AvoBatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AvoBatcher.h; path = AvoInspector/Classes/AvoBatcher.h; sourceTree = "<group>"; };
 		6F5FAE4D95FB6A9732125A383780A679 /* OCMArgAction.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMArgAction.m; path = Source/OCMock/OCMArgAction.m; sourceTree = "<group>"; };
 		6F98DF9AE350D4C80B9BB54E8BBD792C /* UIImage+Compare.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImage+Compare.h"; path = "FBSnapshotTestCase/Categories/UIImage+Compare.h"; sourceTree = "<group>"; };
 		6FD9D030738482969FA185B5402D2F8D /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		70E6B4E2105C14C4F2273B9348DC30C8 /* AvoGuid.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AvoGuid.m; path = AvoInspector/Classes/AvoGuid.m; sourceTree = "<group>"; };
 		7103C493E7D2C94D5B260BD3BFA9C521 /* Specta-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Specta-umbrella.h"; sourceTree = "<group>"; };
 		71AD272BFC423106A60A9BAED18D04D1 /* SEGSegmentIntegration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGSegmentIntegration.h; path = Analytics/Classes/Internal/SEGSegmentIntegration.h; sourceTree = "<group>"; };
-		71E7DAFB0F08BBB855A57628A42B9341 /* AvoEventSchemaType.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = AvoEventSchemaType.h; sourceTree = "<group>"; };
+		7277418CA65ABAD91856DBC474B383C3 /* AvoEncryption.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AvoEncryption.m; path = AvoInspector/Classes/AvoEncryption.m; sourceTree = "<group>"; };
 		733B45146CD181DE2AA25562F2013BE0 /* Pods-AvoStateOfTracking_Tests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-AvoStateOfTracking_Tests-umbrella.h"; sourceTree = "<group>"; };
 		7583DF54BEB576D97684BF5AD63EB1E4 /* OCMNonRetainingObjectReturnValueProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMNonRetainingObjectReturnValueProvider.h; path = Source/OCMock/OCMNonRetainingObjectReturnValueProvider.h; sourceTree = "<group>"; };
 		7674422F374DAFAECC6F1D5B4D057CB9 /* NSNotificationCenter+OCMAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSNotificationCenter+OCMAdditions.m"; path = "Source/OCMock/NSNotificationCenter+OCMAdditions.m"; sourceTree = "<group>"; };
 		769D8F9BDD56901054E3612A1D86EC64 /* OCMockObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMockObject.h; path = Source/OCMock/OCMockObject.h; sourceTree = "<group>"; };
+		7724BA2B5BCF55DA67AF6871B5C2AC1F /* AvoUnknownType.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = AvoUnknownType.h; sourceTree = "<group>"; };
 		7742409ABC834535B941E461617DD66B /* SEGTrackPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGTrackPayload.h; path = Analytics/Classes/Integrations/SEGTrackPayload.h; sourceTree = "<group>"; };
 		786C023A1B667A360983EAC0EACF2BDD /* UIImage+Snapshot.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImage+Snapshot.h"; path = "FBSnapshotTestCase/Categories/UIImage+Snapshot.h"; sourceTree = "<group>"; };
 		788AE818ADA9C260023A98F83BADD6A9 /* OCMInvocationStub.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMInvocationStub.m; path = Source/OCMock/OCMInvocationStub.m; sourceTree = "<group>"; };
 		78CBF77017F8F9190CF4B5F730BA410A /* Analytics.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Analytics.debug.xcconfig; sourceTree = "<group>"; };
+		790F5219355A902DED1E675EADFC01D8 /* AvoEventSchemaType.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = AvoEventSchemaType.h; sourceTree = "<group>"; };
+		7A1886A974A28D063CD5728941C4F2AC /* AvoInspector.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = AvoInspector.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		7C8FF9000F5FE6BFEBF6B6491F152533 /* EXPMatchers+FBSnapshotTest.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "EXPMatchers+FBSnapshotTest.h"; sourceTree = "<group>"; };
 		7CDFAACF25C58B6397D17517F80B0840 /* FBSnapshotTestCase-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "FBSnapshotTestCase-dummy.m"; sourceTree = "<group>"; };
 		7DAB211B9552E88B302BAA3B9546C510 /* EXPExpect.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPExpect.h; path = Expecta/EXPExpect.h; sourceTree = "<group>"; };
+		7E3234141BC0E991DA41BAD84FF304C0 /* AvoInt.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = AvoInt.h; sourceTree = "<group>"; };
 		7E4B33DE716B0DBF5049C29BE873AD9E /* SEGStoreKitTracker.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGStoreKitTracker.m; path = Analytics/Classes/Internal/SEGStoreKitTracker.m; sourceTree = "<group>"; };
 		7E9B7631648F2B80B7039AE2C7998370 /* SPTSharedExampleGroups.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTSharedExampleGroups.m; path = Specta/Specta/SPTSharedExampleGroups.m; sourceTree = "<group>"; };
 		7F1F00A75C3D39C9AFCFA9FBA8D279D0 /* OCMock-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "OCMock-Info.plist"; sourceTree = "<group>"; };
 		805DEFE0420CC0A22DE4AF4022603121 /* OCObserverMockObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCObserverMockObject.m; path = Source/OCMock/OCObserverMockObject.m; sourceTree = "<group>"; };
-		8084EB7CFDB784609B9228960BD5E14A /* AvoAnonymousId.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AvoAnonymousId.m; path = AvoInspector/Classes/AvoAnonymousId.m; sourceTree = "<group>"; };
 		81077B4B065AE8FEAF6E6C3B8396A9FD /* EXPFloatTuple.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPFloatTuple.h; path = Expecta/EXPFloatTuple.h; sourceTree = "<group>"; };
 		82CD04DCED3AE73CB2D01652C30B4811 /* EXPMatchers+equal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+equal.h"; path = "Expecta/Matchers/EXPMatchers+equal.h"; sourceTree = "<group>"; };
 		842BC7D4442DB7D6F4BCC728391A32A1 /* SpectaUtility.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SpectaUtility.m; path = Specta/Specta/SpectaUtility.m; sourceTree = "<group>"; };
 		84409646C7031228B295AD9592A68E95 /* EXPMatchers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPMatchers.h; path = Expecta/Matchers/EXPMatchers.h; sourceTree = "<group>"; };
+		85A7ABFC918C7DAED63625F2BD0B12DA /* AvoUnknownType.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = AvoUnknownType.m; sourceTree = "<group>"; };
 		860B2E29A2F03787759B21D4B7D7765F /* SPTSharedExampleGroups.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTSharedExampleGroups.h; path = Specta/Specta/SPTSharedExampleGroups.h; sourceTree = "<group>"; };
 		86A50513EA76FC0DC323220143C1AAC2 /* SEGHTTPClient.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGHTTPClient.m; path = Analytics/Classes/Internal/SEGHTTPClient.m; sourceTree = "<group>"; };
+		8712A08613885978559646EB7F0574EF /* AvoAnonymousId.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AvoAnonymousId.m; path = AvoInspector/Classes/AvoAnonymousId.m; sourceTree = "<group>"; };
 		8771FE0109D744D85FF4312DF5F07865 /* XCTestCase+Specta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "XCTestCase+Specta.h"; path = "Specta/Specta/XCTestCase+Specta.h"; sourceTree = "<group>"; };
 		8883642E0EC4D8CB56F61BF805E0FA65 /* OCMLocation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMLocation.m; path = Source/OCMock/OCMLocation.m; sourceTree = "<group>"; };
 		8A72939A50EEBC2054E71D8F2033C2E2 /* Pods-AvoStateOfTracking_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-AvoStateOfTracking_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
@@ -626,13 +631,14 @@
 		8CEEA6F4E749D66E501955DD1DDA6692 /* OCMInvocationStub.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMInvocationStub.h; path = Source/OCMock/OCMInvocationStub.h; sourceTree = "<group>"; };
 		8D0B8D2D97B30A9073E1A00A679B3C52 /* Expecta.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Expecta.debug.xcconfig; sourceTree = "<group>"; };
 		8DC1A11306E2D09A0BCF6B078639CFB2 /* SEGHTTPClient.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGHTTPClient.h; path = Analytics/Classes/Internal/SEGHTTPClient.h; sourceTree = "<group>"; };
-		8F66215985DAEABCF94FEA07E35F2641 /* AvoObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = AvoObject.m; sourceTree = "<group>"; };
 		8FCE2016699722CEC2AB6D95EB90707A /* OCMBoxedReturnValueProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMBoxedReturnValueProvider.h; path = Source/OCMock/OCMBoxedReturnValueProvider.h; sourceTree = "<group>"; };
 		903D27BEBCDEA0C74360A1A3679B5606 /* FBSnapshotTestCase-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FBSnapshotTestCase-prefix.pch"; sourceTree = "<group>"; };
 		90E69AF3B19F479B8433D289095E3868 /* Pods-AvoStateOfTracking_Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-AvoStateOfTracking_Tests.modulemap"; sourceTree = "<group>"; };
 		91032CE614CFE5F7F74539CACE55AD20 /* OCProtocolMockObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCProtocolMockObject.h; path = Source/OCMock/OCProtocolMockObject.h; sourceTree = "<group>"; };
 		91C21EC47774D557EC1A8B69745A2525 /* EXPMatchers+endWith.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+endWith.h"; path = "Expecta/Matchers/EXPMatchers+endWith.h"; sourceTree = "<group>"; };
 		9223479EA77FBA1BD66D805B46ADB563 /* SPTCallSite.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTCallSite.m; path = Specta/Specta/SPTCallSite.m; sourceTree = "<group>"; };
+		929B9AA67483862EEB4B5FA238D2DB15 /* AvoList.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = AvoList.m; sourceTree = "<group>"; };
+		92CB4D38795C5907816E28F955B48160 /* AvoEventSpecFetchTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AvoEventSpecFetchTypes.h; path = AvoInspector/Classes/AvoEventSpecFetchTypes.h; sourceTree = "<group>"; };
 		92E063AEC0C1D2F181AB2D61DA3D63C2 /* EXPMatchers+beSubclassOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beSubclassOf.m"; path = "Expecta/Matchers/EXPMatchers+beSubclassOf.m"; sourceTree = "<group>"; };
 		93880751CDEE03AAB0E2EFF1286F9A6E /* UIViewController+SEGScreen.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIViewController+SEGScreen.h"; path = "Analytics/Classes/Internal/UIViewController+SEGScreen.h"; sourceTree = "<group>"; };
 		93E281E64A60B7EE7E1915D8F0BA8D0F /* SPTSpec.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTSpec.h; path = Specta/Specta/SPTSpec.h; sourceTree = "<group>"; };
@@ -641,27 +647,25 @@
 		94A5D04C74141BDB47E9AA8E4CB68535 /* ExpectaObject+FBSnapshotTest.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "ExpectaObject+FBSnapshotTest.m"; sourceTree = "<group>"; };
 		9521B6BCAC2FDCBC6BCA32EC240AD55B /* Expecta.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Expecta.release.xcconfig; sourceTree = "<group>"; };
 		958F6E8E00AC8CA64CA1487C047AF5A2 /* EXPMatchers+beIdenticalTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beIdenticalTo.m"; path = "Expecta/Matchers/EXPMatchers+beIdenticalTo.m"; sourceTree = "<group>"; };
-		95B33555E3C4E808A8893BDDED3627AD /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
 		95EC507E4CFAB5583FD5B56793A5B17D /* Pods-AvoStateOfTracking_Example */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = "Pods-AvoStateOfTracking_Example"; path = Pods_AvoStateOfTracking_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		97479C4E30D1DF03E4C97C85B7EA50D3 /* OCMock.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMock.h; path = Source/OCMock/OCMock.h; sourceTree = "<group>"; };
-		99805C28CAC664ED729B1456ED867815 /* AvoEventSpecFetchTypes.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AvoEventSpecFetchTypes.m; path = AvoInspector/Classes/AvoEventSpecFetchTypes.m; sourceTree = "<group>"; };
-		99C83184B0AF5E532B2101A5C36DFAAD /* AvoInspector.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AvoInspector.debug.xcconfig; sourceTree = "<group>"; };
+		97703A195D2DE48F1EAAE3817B59AA8E /* AvoInspector.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AvoInspector.release.xcconfig; sourceTree = "<group>"; };
+		978C57D230C03D13B4B87709F074A17D /* AvoNetworkCallsHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AvoNetworkCallsHandler.m; path = AvoInspector/Classes/AvoNetworkCallsHandler.m; sourceTree = "<group>"; };
 		9AAB4B8649A219B3831EC0C635F3EC40 /* EXPMatchers+raiseWithReason.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+raiseWithReason.m"; path = "Expecta/Matchers/EXPMatchers+raiseWithReason.m"; sourceTree = "<group>"; };
 		9B0AD33E190C33729F51E0C2F384ABDF /* SEGTrackPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGTrackPayload.m; path = Analytics/Classes/Integrations/SEGTrackPayload.m; sourceTree = "<group>"; };
 		9B1C8E49866C1A7400FF289BD690C869 /* EXPMatchers+beGreaterThan.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beGreaterThan.h"; path = "Expecta/Matchers/EXPMatchers+beGreaterThan.h"; sourceTree = "<group>"; };
 		9BDB14440C65727C9552B805F4E176A5 /* SEGIntegration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGIntegration.h; path = Analytics/Classes/Integrations/SEGIntegration.h; sourceTree = "<group>"; };
+		9CDA5569773A911B202D725A6F48C164 /* AvoInspector-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AvoInspector-umbrella.h"; sourceTree = "<group>"; };
 		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		9EDA2266AEC61739C4732CA1252C2747 /* SEGGroupPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGGroupPayload.h; path = Analytics/Classes/Integrations/SEGGroupPayload.h; sourceTree = "<group>"; };
 		9F01EE3CB23DBACE6031AC0C708F9835 /* EXPMatchers+respondTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+respondTo.h"; path = "Expecta/Matchers/EXPMatchers+respondTo.h"; sourceTree = "<group>"; };
 		9F4E3AE922C13A8311FB93FACCA641E9 /* Expecta+Snapshots-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Expecta+Snapshots-prefix.pch"; sourceTree = "<group>"; };
-		9F72FE2576CBFDB3DA6ED0E0B751F289 /* AvoGuid.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AvoGuid.h; path = AvoInspector/Classes/AvoGuid.h; sourceTree = "<group>"; };
 		9F9F642AC01805479229379C0A3DEC42 /* NSValue+Expecta.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValue+Expecta.m"; path = "Expecta/NSValue+Expecta.m"; sourceTree = "<group>"; };
 		9FE96EA2314E98B7954A519F5FDD82A9 /* EXPDefines.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPDefines.h; path = Expecta/EXPDefines.h; sourceTree = "<group>"; };
 		A079A922F76B0C044035931B3F95F8B5 /* Specta.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Specta.release.xcconfig; sourceTree = "<group>"; };
 		A1FEBA2788095607F65091A7E712D455 /* EXPMatchers+beInTheRangeOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beInTheRangeOf.m"; path = "Expecta/Matchers/EXPMatchers+beInTheRangeOf.m"; sourceTree = "<group>"; };
 		A283247A6F3CF81322E266BA8819BE3B /* FBSnapshotTestCase.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = FBSnapshotTestCase.release.xcconfig; sourceTree = "<group>"; };
 		A28A1D54B29BA3856CF4E339E8F0AF37 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
-		A2A9155F3D40E48C863C42E4945E7F93 /* AvoInt.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = AvoInt.m; sourceTree = "<group>"; };
 		A387AAFB425E565BF79841943F7C7BC2 /* Expecta+Snapshots.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Expecta+Snapshots.release.xcconfig"; sourceTree = "<group>"; };
 		A401BC8F87897E4D26F78A7E5E7A42EA /* EXPMatchers+match.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+match.m"; path = "Expecta/Matchers/EXPMatchers+match.m"; sourceTree = "<group>"; };
 		A432466058947C886C625848076C89E9 /* Pods-AvoStateOfTracking_Tests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-AvoStateOfTracking_Tests-Info.plist"; sourceTree = "<group>"; };
@@ -669,44 +673,45 @@
 		A73507CE7F6904EC381D839FFD87CB8A /* OCMExceptionReturnValueProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMExceptionReturnValueProvider.m; path = Source/OCMock/OCMExceptionReturnValueProvider.m; sourceTree = "<group>"; };
 		A7E40F96297E3787C72C2C31FC3F3ED8 /* Expecta-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Expecta-dummy.m"; sourceTree = "<group>"; };
 		A953E713899B72D2C15FC4DF168CD115 /* SEGFileStorage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGFileStorage.h; path = Analytics/Classes/Internal/SEGFileStorage.h; sourceTree = "<group>"; };
-		A99C63629A66DBC947FF078AFB7A7F14 /* AvoInspector.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = AvoInspector.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		A9E9475BC83D816365989EC0B6C35DE6 /* AvoUnknownType.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = AvoUnknownType.h; sourceTree = "<group>"; };
-		A9F3578ABD4F65B3E5BCB1CEE7092373 /* AvoAnonymousId.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AvoAnonymousId.h; path = AvoInspector/Classes/AvoAnonymousId.h; sourceTree = "<group>"; };
 		ABA1E4EA47280C2E32B91FEAAF573CF1 /* Pods-AvoStateOfTracking_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-AvoStateOfTracking_Example.debug.xcconfig"; sourceTree = "<group>"; };
-		ABCF0D077978AAB841F0BBA3F30ED727 /* Inspector.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Inspector.h; path = AvoInspector/Classes/Inspector.h; sourceTree = "<group>"; };
 		ADB08FED406212B6FDF0660E33120258 /* OCObserverMockObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCObserverMockObject.h; path = Source/OCMock/OCObserverMockObject.h; sourceTree = "<group>"; };
+		ADD074A6D2F56D7995D2A20543DADB67 /* AvoBatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AvoBatcher.h; path = AvoInspector/Classes/AvoBatcher.h; sourceTree = "<group>"; };
 		B03394A10FDC608BF1B787666A1AB2CB /* EXPExpect.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPExpect.m; path = Expecta/EXPExpect.m; sourceTree = "<group>"; };
-		B0FCCB3593AB7973336A143FFE47B7C8 /* AvoFloat.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = AvoFloat.h; sourceTree = "<group>"; };
+		B13924B2208998F2F0E3C632E8AB9E03 /* AvoEncryption.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AvoEncryption.h; path = AvoInspector/Classes/AvoEncryption.h; sourceTree = "<group>"; };
 		B180DE978EFDC49034AF1F2263406B33 /* OCMBlockArgCaller.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMBlockArgCaller.h; path = Source/OCMock/OCMBlockArgCaller.h; sourceTree = "<group>"; };
 		B21D73849F6FA68401D2C5A686F3F390 /* OCMMacroState.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMMacroState.m; path = Source/OCMock/OCMMacroState.m; sourceTree = "<group>"; };
+		B2C3DBD54E74DFE6F68A326C4C73C41A /* AvoEventValidator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AvoEventValidator.h; path = AvoInspector/Classes/AvoEventValidator.h; sourceTree = "<group>"; };
 		B2FCCAD5D087C07660045F33184DFDE5 /* Expecta-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Expecta-prefix.pch"; sourceTree = "<group>"; };
+		B315AD2E8094367F5673EA0654B86644 /* AvoInt.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = AvoInt.m; sourceTree = "<group>"; };
 		B3307F68BC7948C6C2B0D789490C8193 /* UIImage+Snapshot.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImage+Snapshot.m"; path = "FBSnapshotTestCase/Categories/UIImage+Snapshot.m"; sourceTree = "<group>"; };
-		B3A49134759A9800259E2801FDF90492 /* AvoBoolean.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = AvoBoolean.m; sourceTree = "<group>"; };
 		B3B95C173157B2241C14240E19E4F8D6 /* OCMNotificationPoster.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMNotificationPoster.h; path = Source/OCMock/OCMNotificationPoster.h; sourceTree = "<group>"; };
 		B3E14AD7CC18650F5828D44912CE1285 /* Specta.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Specta.debug.xcconfig; sourceTree = "<group>"; };
+		B4743E5C1E850A199511C65D8C8A6036 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
 		B5024D6273F5A704A0A131AD1F2D6013 /* NSValue+OCMAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValue+OCMAdditions.h"; path = "Source/OCMock/NSValue+OCMAdditions.h"; sourceTree = "<group>"; };
-		B53B03FE51473DF05F79B4A61BA3C381 /* AvoGuid.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AvoGuid.m; path = AvoInspector/Classes/AvoGuid.m; sourceTree = "<group>"; };
 		B648F0E33A09B1C85DD9AF56CDE61DE9 /* OCMStubRecorder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMStubRecorder.h; path = Source/OCMock/OCMStubRecorder.h; sourceTree = "<group>"; };
 		B6F22BEDB958A3136549B1D04EF4EA0C /* SEGReachability.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGReachability.h; path = Analytics/Vendor/SEGReachability.h; sourceTree = "<group>"; };
 		B6F4B7E28E13DDCA0F6242B8AAF02FAE /* OCMExpectationRecorder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMExpectationRecorder.m; path = Source/OCMock/OCMExpectationRecorder.m; sourceTree = "<group>"; };
 		B706138C20ED2A92BC90DF34C0312276 /* FBSnapshotTestCase.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = FBSnapshotTestCase.modulemap; sourceTree = "<group>"; };
 		B7741941AD68BCFC2257F9B4EAFAA6B6 /* EXPMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPMatcher.h; path = Expecta/EXPMatcher.h; sourceTree = "<group>"; };
 		B7CE1D904E4CF1FBA6AD580DC6DBCDDE /* SEGAES256Crypto.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGAES256Crypto.h; path = Analytics/Classes/Crypto/SEGAES256Crypto.h; sourceTree = "<group>"; };
-		BA44CED3073504D76FD4B66BA0BB9260 /* ResourceBundle-AvoInspector-AvoInspector-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "ResourceBundle-AvoInspector-AvoInspector-Info.plist"; sourceTree = "<group>"; };
 		BAB35ECF4279470E561AD0CDB58D632D /* SPTExample.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTExample.h; path = Specta/Specta/SPTExample.h; sourceTree = "<group>"; };
 		BAE6C3D2DDEAFB47A7CFB8DBA640A335 /* SEGAnalytics.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGAnalytics.m; path = Analytics/Classes/SEGAnalytics.m; sourceTree = "<group>"; };
 		BB1732BFBFB65C844C7A44B2D7FFB24F /* UIImage+Diff.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImage+Diff.h"; path = "FBSnapshotTestCase/Categories/UIImage+Diff.h"; sourceTree = "<group>"; };
 		BC6C25497ADFD74DA84FD51E24FBD427 /* UIApplication+StrictKeyWindow.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIApplication+StrictKeyWindow.m"; path = "FBSnapshotTestCase/Categories/UIApplication+StrictKeyWindow.m"; sourceTree = "<group>"; };
+		BDEA666C356BE70AD8AA26F5A151EB15 /* AvoString.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = AvoString.h; sourceTree = "<group>"; };
 		BEA410302EA9077EC89C75F9238C30F2 /* EXPMatchers+beTruthy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beTruthy.m"; path = "Expecta/Matchers/EXPMatchers+beTruthy.m"; sourceTree = "<group>"; };
+		BEC87A3F51FB9891C52014745531E9A8 /* ResourceBundle-AvoInspector-AvoInspector-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "ResourceBundle-AvoInspector-AvoInspector-Info.plist"; sourceTree = "<group>"; };
 		BF56796BCB4D909B3C9F786259E60F7A /* FBSnapshotTestCase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = FBSnapshotTestCase.m; path = FBSnapshotTestCase/FBSnapshotTestCase.m; sourceTree = "<group>"; };
 		BF99F873584873D3483C036AF27199BA /* EXPMatchers+beSupersetOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beSupersetOf.m"; path = "Expecta/Matchers/EXPMatchers+beSupersetOf.m"; sourceTree = "<group>"; };
-		BFF320C496B06A51EE9AF62FD9F939BF /* AvoDeduplicator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AvoDeduplicator.h; path = AvoInspector/Classes/AvoDeduplicator.h; sourceTree = "<group>"; };
+		BFE9216CA56AE869328FE543F9533EBC /* AvoNull.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = AvoNull.h; sourceTree = "<group>"; };
 		C04527F50C4D4E7833EA6D4FDC247B35 /* EXPBlockDefinedMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPBlockDefinedMatcher.m; path = Expecta/EXPBlockDefinedMatcher.m; sourceTree = "<group>"; };
 		C0DDC7EE19BA24F7E1159D83D9EEBBF1 /* SEGFileStorage.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGFileStorage.m; path = Analytics/Classes/Internal/SEGFileStorage.m; sourceTree = "<group>"; };
 		C0EEFEAEEBFCF07336C1D6E6A2B70775 /* EXPUnsupportedObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPUnsupportedObject.h; path = Expecta/EXPUnsupportedObject.h; sourceTree = "<group>"; };
 		C0F2DA277944461CD09092641F36E6BE /* OCMockObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMockObject.m; path = Source/OCMock/OCMockObject.m; sourceTree = "<group>"; };
+		C14985C09E15E0916D142E841B41BE0F /* AvoBatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AvoBatcher.m; path = AvoInspector/Classes/AvoBatcher.m; sourceTree = "<group>"; };
 		C339C5030321B7D40789BB49823794F3 /* OCMArg.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMArg.h; path = Source/OCMock/OCMArg.h; sourceTree = "<group>"; };
 		C3C48197D5DBA9C81B3C385DE9FF6573 /* NSObject+Expecta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+Expecta.h"; path = "Expecta/NSObject+Expecta.h"; sourceTree = "<group>"; };
+		C3F0FB594533465FEFC208DE37070108 /* AvoNetworkCallsHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AvoNetworkCallsHandler.h; path = AvoInspector/Classes/AvoNetworkCallsHandler.h; sourceTree = "<group>"; };
 		C5007A65FD3E11CD2D12AE75A04744D1 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/QuartzCore.framework; sourceTree = DEVELOPER_DIR; };
 		C7AF1865DD3A3C49C81D26035B35FCEE /* EXPMatchers+postNotification.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+postNotification.h"; path = "Expecta/Matchers/EXPMatchers+postNotification.h"; sourceTree = "<group>"; };
 		C7FF9A52C7EDA26E8077A15FB096507E /* OCMock-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "OCMock-dummy.m"; sourceTree = "<group>"; };
@@ -714,61 +719,61 @@
 		C8E18538FA64F773053BD0C177BACC13 /* OCMock-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "OCMock-umbrella.h"; sourceTree = "<group>"; };
 		C9485FE00D528E73468E8626474AD42B /* SEGReachability.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGReachability.m; path = Analytics/Vendor/SEGReachability.m; sourceTree = "<group>"; };
 		C96C65747FFA546BE09E893C8968D133 /* SEGIntegrationsManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGIntegrationsManager.h; path = Analytics/Classes/Integrations/SEGIntegrationsManager.h; sourceTree = "<group>"; };
-		CAF06CF564FB71A1B0FF2732C4014659 /* AvoUtils.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AvoUtils.m; path = AvoInspector/Classes/AvoUtils.m; sourceTree = "<group>"; };
 		CB6D256782384030E520A854CECC2152 /* EXPMatchers+beCloseTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beCloseTo.h"; path = "Expecta/Matchers/EXPMatchers+beCloseTo.h"; sourceTree = "<group>"; };
 		CC24C518F0D66A97FE28F023A2C6949A /* SEGIdentifyPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGIdentifyPayload.h; path = Analytics/Classes/Integrations/SEGIdentifyPayload.h; sourceTree = "<group>"; };
 		CD53A67DC11CD79B70E9160EC7AC07C2 /* SPTTestSuite.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTTestSuite.h; path = Specta/Specta/SPTTestSuite.h; sourceTree = "<group>"; };
 		CE2054E2EFC8A89E9277A44FB810161E /* SPTTestSuite.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTTestSuite.m; path = Specta/Specta/SPTTestSuite.m; sourceTree = "<group>"; };
-		CE4E03A6152FD02F67111E49C036B2E2 /* AvoBatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AvoBatcher.m; path = AvoInspector/Classes/AvoBatcher.m; sourceTree = "<group>"; };
 		CE7C80AE372612043592D40888C9D2A8 /* EXPMatchers+beGreaterThan.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beGreaterThan.m"; path = "Expecta/Matchers/EXPMatchers+beGreaterThan.m"; sourceTree = "<group>"; };
 		CF3203ABFD24AC89373B929B927C5FA3 /* OCMArgAction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMArgAction.h; path = Source/OCMock/OCMArgAction.h; sourceTree = "<group>"; };
 		D01EC2FD36930C96F8C76E873B521051 /* OCClassMockObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCClassMockObject.m; path = Source/OCMock/OCClassMockObject.m; sourceTree = "<group>"; };
-		D146E811960E58664C00916F1D264AC5 /* AvoInspector.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AvoInspector.modulemap; sourceTree = "<group>"; };
-		D1FBE712CE2C234BD94FF6A5D830E36A /* AvoInspector-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AvoInspector-prefix.pch"; sourceTree = "<group>"; };
-		D2B0A62A430CB996421976D614FE9F47 /* AvoEventSpecCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AvoEventSpecCache.h; path = AvoInspector/Classes/AvoEventSpecCache.h; sourceTree = "<group>"; };
 		D32F418D184BC8A122AB17CF79DB7F7A /* FBSnapshotTestCasePlatform.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FBSnapshotTestCasePlatform.h; path = FBSnapshotTestCase/FBSnapshotTestCasePlatform.h; sourceTree = "<group>"; };
-		D4C222E409A85E689ED2359DD9FE5245 /* AvoEventSpecFetcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AvoEventSpecFetcher.h; path = AvoInspector/Classes/AvoEventSpecFetcher.h; sourceTree = "<group>"; };
-		D522AA9D98D2EFB77EC6371A3E73D6E8 /* AvoEventSpecCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AvoEventSpecCache.m; path = AvoInspector/Classes/AvoEventSpecCache.m; sourceTree = "<group>"; };
+		D356E6789FFA488A8D25A1DF6958C45B /* AvoInspector-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AvoInspector-dummy.m"; sourceTree = "<group>"; };
+		D5379B80E1DFF854F55F4AF937493F3F /* Inspector.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Inspector.h; path = AvoInspector/Classes/Inspector.h; sourceTree = "<group>"; };
 		D538AE56B9FA797ED14D462EE9542A4D /* Pods-AvoStateOfTracking_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-AvoStateOfTracking_Example-umbrella.h"; sourceTree = "<group>"; };
-		D541A5CA0804C0BE75FA4EBC855146D9 /* AvoEventSchemaType.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = AvoEventSchemaType.m; sourceTree = "<group>"; };
 		D61DAA7C76FDC961C4E0993549C15B11 /* EXPMatchers+haveCountOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+haveCountOf.h"; path = "Expecta/Matchers/EXPMatchers+haveCountOf.h"; sourceTree = "<group>"; };
 		D6F29A9E16A0389960A45F948AEA89C5 /* EXPFloatTuple.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPFloatTuple.m; path = Expecta/EXPFloatTuple.m; sourceTree = "<group>"; };
 		D6F4C93809358945C92ACF497AF4804D /* Analytics-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Analytics-dummy.m"; sourceTree = "<group>"; };
 		D85836D70C6ECFA262C7EEF374490F99 /* SPTSpec.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTSpec.m; path = Specta/Specta/SPTSpec.m; sourceTree = "<group>"; };
-		D962E8DD98717C2F4E5B56CA72930AB0 /* AvoUtils.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AvoUtils.h; path = AvoInspector/Classes/AvoUtils.h; sourceTree = "<group>"; };
+		DB0FCD211D625E73AB05085B50615ADA /* AvoUtils.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AvoUtils.m; path = AvoInspector/Classes/AvoUtils.m; sourceTree = "<group>"; };
 		DB48450C71C5ADDFC15289FDE17F5776 /* OCMRealObjectForwarder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMRealObjectForwarder.m; path = Source/OCMock/OCMRealObjectForwarder.m; sourceTree = "<group>"; };
 		DB735423DFC4FFC71D81806AEBBC8B31 /* Pods-AvoStateOfTracking_Example-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-AvoStateOfTracking_Example-Info.plist"; sourceTree = "<group>"; };
 		DBDDB7AF3CE40181BC4B60797480BD61 /* OCMInvocationExpectation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMInvocationExpectation.h; path = Source/OCMock/OCMInvocationExpectation.h; sourceTree = "<group>"; };
 		DBE88333832815438B420B38F0416993 /* AvoInspector-AvoInspector */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = "AvoInspector-AvoInspector"; path = AvoInspector.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC4BFE4E1FEA914279F802CBF41EE034 /* Expecta+Snapshots-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Expecta+Snapshots-dummy.m"; sourceTree = "<group>"; };
+		DDC8740D93D55A37485D5696466F8FF6 /* AvoBoolean.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = AvoBoolean.m; sourceTree = "<group>"; };
 		E0EFFE5BDD07D50C2D11C1027FEB4C41 /* ExpectaObject+FBSnapshotTest.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "ExpectaObject+FBSnapshotTest.h"; sourceTree = "<group>"; };
 		E116588B2D2A51B9C133951E03A039D2 /* SEGStoreKitTracker.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGStoreKitTracker.h; path = Analytics/Classes/Internal/SEGStoreKitTracker.h; sourceTree = "<group>"; };
 		E17CA18BBD6AF8C5765DF73136C50564 /* UIViewController+SEGScreen.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIViewController+SEGScreen.m"; path = "Analytics/Classes/Internal/UIViewController+SEGScreen.m"; sourceTree = "<group>"; };
-		E1E2556DB4880FEA7020412FFB9670A1 /* AvoDeduplicator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AvoDeduplicator.m; path = AvoInspector/Classes/AvoDeduplicator.m; sourceTree = "<group>"; };
 		E25F299BBCF8EDB133A39FF6B8A2C667 /* NSNotificationCenter+OCMAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSNotificationCenter+OCMAdditions.h"; path = "Source/OCMock/NSNotificationCenter+OCMAdditions.h"; sourceTree = "<group>"; };
 		E3B4DE6E725CD4188B3F3B7FBECDEA39 /* OCMQuantifier.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMQuantifier.m; path = Source/OCMock/OCMQuantifier.m; sourceTree = "<group>"; };
 		E409E3B194ABF4DC805AEDC3566BA639 /* Pods-AvoStateOfTracking_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-AvoStateOfTracking_Example-acknowledgements.plist"; sourceTree = "<group>"; };
 		E4699799B8F7E4ADDB0CC1B364CC5747 /* SPTExampleGroup.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTExampleGroup.h; path = Specta/Specta/SPTExampleGroup.h; sourceTree = "<group>"; };
 		E694CE0F6FD21CAE949C9E3B83CDD786 /* EXPMatchers+beKindOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beKindOf.m"; path = "Expecta/Matchers/EXPMatchers+beKindOf.m"; sourceTree = "<group>"; };
 		E72C14D1513A1953FC5EFF4846C61D2F /* Specta-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Specta-prefix.pch"; sourceTree = "<group>"; };
+		E732305A85BEB916577CA35320C790BD /* AvoDeduplicator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AvoDeduplicator.h; path = AvoInspector/Classes/AvoDeduplicator.h; sourceTree = "<group>"; };
 		E79C056087F64BE8CFB39AB625574413 /* EXPMatchers+beKindOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beKindOf.h"; path = "Expecta/Matchers/EXPMatchers+beKindOf.h"; sourceTree = "<group>"; };
 		E7A1C823D31251CBB362600D8585E72E /* FBSnapshotTestController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = FBSnapshotTestController.m; path = FBSnapshotTestCase/FBSnapshotTestController.m; sourceTree = "<group>"; };
 		E7C0CCA7DF2FBE1A6E77E1929A88838A /* NSData+SEGGZIP.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSData+SEGGZIP.h"; path = "Analytics/Classes/Internal/NSData+SEGGZIP.h"; sourceTree = "<group>"; };
 		E7F9C7F5DF9639A7953FBD51132A691D /* SEGAnalyticsUtils.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGAnalyticsUtils.m; path = Analytics/Classes/Internal/SEGAnalyticsUtils.m; sourceTree = "<group>"; };
+		E9700210CA98FDE33B1696F43A998E1B /* AvoInspector.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AvoInspector.m; path = AvoInspector/Classes/AvoInspector.m; sourceTree = "<group>"; };
 		EB53F464B5FDB2D0E27095907735E04C /* EXPMatchers+beFalsy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beFalsy.h"; path = "Expecta/Matchers/EXPMatchers+beFalsy.h"; sourceTree = "<group>"; };
+		EC2E169879776C38C36D0887B44E3213 /* AvoEventSpecFetchTypes.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AvoEventSpecFetchTypes.m; path = AvoInspector/Classes/AvoEventSpecFetchTypes.m; sourceTree = "<group>"; };
 		EC678BB5550440D42DF6B2FFE94F7A01 /* EXPMatchers+beNil.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beNil.m"; path = "Expecta/Matchers/EXPMatchers+beNil.m"; sourceTree = "<group>"; };
 		EC94485C8B9B23BB9D85AE46B2317822 /* Pods-AvoStateOfTracking_Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-AvoStateOfTracking_Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
 		EC9C902129ADABE5DEF960D3A70EA3E4 /* Specta-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Specta-dummy.m"; sourceTree = "<group>"; };
 		ECF12A02387B6EFCC13650016ADA4C8A /* EXPMatchers+postNotification.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+postNotification.m"; path = "Expecta/Matchers/EXPMatchers+postNotification.m"; sourceTree = "<group>"; };
 		ED1031AEE0C24D29CC0371B0D180C3CD /* OCPartialMockObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCPartialMockObject.m; path = Source/OCMock/OCPartialMockObject.m; sourceTree = "<group>"; };
-		ED2BCE000322D29BE433E9221F9BC75A /* AvoInt.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = AvoInt.h; sourceTree = "<group>"; };
 		ED301411CB1F794E1EA1CFF291DC6720 /* OCMObserverRecorder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMObserverRecorder.m; path = Source/OCMock/OCMObserverRecorder.m; sourceTree = "<group>"; };
+		ED61FDE0E154F68B00CA7E96CD8BEDE2 /* AvoEventSpecCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AvoEventSpecCache.h; path = AvoInspector/Classes/AvoEventSpecCache.h; sourceTree = "<group>"; };
 		ED8ED6AC142CCB3989148E8C104B5563 /* OCMPassByRefSetter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMPassByRefSetter.m; path = Source/OCMock/OCMPassByRefSetter.m; sourceTree = "<group>"; };
 		EE563C277281A6C72B5F76026D19F921 /* EXPMatchers+beGreaterThanOrEqualTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beGreaterThanOrEqualTo.m"; path = "Expecta/Matchers/EXPMatchers+beGreaterThanOrEqualTo.m"; sourceTree = "<group>"; };
 		F064E29934683EA840450B31EF1279B3 /* SEGAliasPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGAliasPayload.h; path = Analytics/Classes/Integrations/SEGAliasPayload.h; sourceTree = "<group>"; };
 		F0A136C08DE3FC6D96E7B4C27DA6CEA4 /* NSMethodSignature+OCMAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSMethodSignature+OCMAdditions.m"; path = "Source/OCMock/NSMethodSignature+OCMAdditions.m"; sourceTree = "<group>"; };
+		F1AF6F5996B72F2B43C2000663A91424 /* AvoObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = AvoObject.h; sourceTree = "<group>"; };
 		F1EAE4762AEC1597B642638CCFC68C54 /* OCMRealObjectForwarder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMRealObjectForwarder.h; path = Source/OCMock/OCMRealObjectForwarder.h; sourceTree = "<group>"; };
+		F1FADC3424633DA8A2362EF57E408A86 /* AvoString.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = AvoString.m; sourceTree = "<group>"; };
 		F24FB3D905866F113C184B959133399B /* SEGAnalytics.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGAnalytics.h; path = Analytics/Classes/SEGAnalytics.h; sourceTree = "<group>"; };
+		F25FC41FBBB86BB5B909408B73977416 /* AvoAnonymousId.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AvoAnonymousId.h; path = AvoInspector/Classes/AvoAnonymousId.h; sourceTree = "<group>"; };
 		F2AB6AE5A003B408B66B6DF5FEF62423 /* FBSnapshotTestCase.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = FBSnapshotTestCase.debug.xcconfig; sourceTree = "<group>"; };
 		F2BC63153CAE845052DE6CBD718231A0 /* EXPMatchers+beInstanceOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beInstanceOf.h"; path = "Expecta/Matchers/EXPMatchers+beInstanceOf.h"; sourceTree = "<group>"; };
 		F30A5C503F1A81D96514140BAD3D22A8 /* NSMethodSignature+OCMAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSMethodSignature+OCMAdditions.h"; path = "Source/OCMock/NSMethodSignature+OCMAdditions.h"; sourceTree = "<group>"; };
@@ -779,43 +784,30 @@
 		F5DCB74EADEB23944B3B9AC4AE45563B /* EXPMatcherHelpers.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPMatcherHelpers.m; path = Expecta/Matchers/EXPMatcherHelpers.m; sourceTree = "<group>"; };
 		F5ECA8DF5A40CCF3DD4310D04BB946CD /* OCClassMockObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCClassMockObject.h; path = Source/OCMock/OCClassMockObject.h; sourceTree = "<group>"; };
 		F6349CB56C9BE5592A69B056A5E70E5A /* FBSnapshotTestCase-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FBSnapshotTestCase-umbrella.h"; sourceTree = "<group>"; };
-		F822A7A01960459C00E77F4AB5923A81 /* AvoInspector-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AvoInspector-dummy.m"; sourceTree = "<group>"; };
 		F8A112AFB4227A4D0980F5746F9C2A5E /* NSObject+OCMAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+OCMAdditions.h"; path = "Source/OCMock/NSObject+OCMAdditions.h"; sourceTree = "<group>"; };
 		F9E6666EB39D806594114E9C34DA3895 /* NSValue+Expecta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValue+Expecta.h"; path = "Expecta/NSValue+Expecta.h"; sourceTree = "<group>"; };
 		FBB018F530B93A9ED2C74DE720CA21A8 /* EXPMatchers+conformTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+conformTo.m"; path = "Expecta/Matchers/EXPMatchers+conformTo.m"; sourceTree = "<group>"; };
 		FD2EE004EC3EF6EC7CC50213F9215993 /* SEGUtils.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGUtils.h; path = Analytics/Classes/Internal/SEGUtils.h; sourceTree = "<group>"; };
+		FD323F46B9B5AE0A51E0DA88761CC07D /* AvoInspector.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AvoInspector.debug.xcconfig; sourceTree = "<group>"; };
 		FDFDD9BE0F0B4763C500012041C6A7F5 /* OCMPassByRefSetter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMPassByRefSetter.h; path = Source/OCMock/OCMPassByRefSetter.h; sourceTree = "<group>"; };
 		FE74E167A27584EC09C74A47628ADB14 /* SEGCrypto.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGCrypto.h; path = Analytics/Classes/Crypto/SEGCrypto.h; sourceTree = "<group>"; };
 		FEE4BD74DA6CF38AF62C2BC40C690B18 /* SEGUtils.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGUtils.m; path = Analytics/Classes/Internal/SEGUtils.m; sourceTree = "<group>"; };
 		FFC64F6F4889335B65F1A49636C8205F /* OCMArg.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMArg.m; path = Source/OCMock/OCMArg.m; sourceTree = "<group>"; };
-		FFD0123BA1BEE2B87FF68A6650E61219 /* AvoInspector-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AvoInspector-Info.plist"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		0D86C9EAF2455DD7BEA3BD4847FB8017 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		171F2C4BCC55F42C3F3F183E7BCE7974 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				22D05B7D1780F23AEE1D9DDD675CB545 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		5F231B0357D58A815A72D47D2A290AC4 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				0074EDFA6F113371C756BEC02C8754D3 /* Foundation.framework in Frameworks */,
-				1464C324652605EC79387E66A9325A55 /* QuartzCore.framework in Frameworks */,
-				1E2CEBB515AF3056E15AD96A0DBD2491 /* UIKit.framework in Frameworks */,
-				429200C00789F2352232E9660866C8CA /* XCTest.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		7434F97D1554119021448756C5C716FB /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				49361FACCA43C555F0EBBD4AB666358C /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -836,6 +828,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		989DCC880C95F320026AFFDDC69F4117 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				43D5C2A5619DC92B19A60B0C015AAF03 /* Foundation.framework in Frameworks */,
+				4FF0D127E423572646DE82C0F5F26FD1 /* XCTest.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9C56453ADDA70B8B584C2E4167099A58 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -845,28 +846,31 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A2D0103A6FD629C3FE0463813D6C2D6C /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				B08C3D6C489980A20D76907C02FEE6B1 /* Foundation.framework in Frameworks */,
-				FF21BD6FE3D52EF4015615586FAD4BF8 /* XCTest.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		AF76CDA69BF30B885282A990096F16C3 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		B30C3A05604AB9FF572AFCA6CC8903B8 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				C30A7E1682336A5A02B728755B624095 /* Foundation.framework in Frameworks */,
 				C03C8F5FE7EB66675E3B7F85AA974D97 /* XCTest.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C654922FDC41B3F3BDBEE8B479262A8C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A92E3888903993BC3FED1E48A37BB393 /* Foundation.framework in Frameworks */,
+				AD49198DD9B5607C4D54AB48C398F72E /* QuartzCore.framework in Frameworks */,
+				2F8877AFC58AE55B695425D8256F36F9 /* UIKit.framework in Frameworks */,
+				689AFC19C878AC4737100A4E9CFC8A45 /* XCTest.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DEF42948920BE1D2BE7C97D6741731FE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7A6F9297CE2E19A667F3491F635DDDD7 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -881,6 +885,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		080D05E07C6B279DA4A7E3A8950D0660 /* Pod */ = {
+			isa = PBXGroup;
+			children = (
+				7A1886A974A28D063CD5728941C4F2AC /* AvoInspector.podspec */,
+				B4743E5C1E850A199511C65D8C8A6036 /* LICENSE */,
+				2D6EF0EBCD80431119543F461AED41A1 /* README.md */,
+			);
+			name = Pod;
+			sourceTree = "<group>";
+		};
 		0C072BB9F737AFA70CF5B0BC268CAA3A /* Expecta */ = {
 			isa = PBXGroup;
 			children = (
@@ -980,32 +994,6 @@
 			path = "Target Support Files/Pods-AvoStateOfTracking_Example";
 			sourceTree = "<group>";
 		};
-		1FB7F2ED4B401F9A3D9E3AF5419D7252 /* eventschematypes */ = {
-			isa = PBXGroup;
-			children = (
-				02E4E3B41C978135D4585CC4BF112F7B /* AvoBoolean.h */,
-				B3A49134759A9800259E2801FDF90492 /* AvoBoolean.m */,
-				71E7DAFB0F08BBB855A57628A42B9341 /* AvoEventSchemaType.h */,
-				D541A5CA0804C0BE75FA4EBC855146D9 /* AvoEventSchemaType.m */,
-				B0FCCB3593AB7973336A143FFE47B7C8 /* AvoFloat.h */,
-				6586F0F76E995B08E6A6CF7B3C9EC667 /* AvoFloat.m */,
-				ED2BCE000322D29BE433E9221F9BC75A /* AvoInt.h */,
-				A2A9155F3D40E48C863C42E4945E7F93 /* AvoInt.m */,
-				14CCB198FEB5532679FF53BA56912589 /* AvoList.h */,
-				6DCDCCB631E371C4BE0D5B4020B2327A /* AvoList.m */,
-				47788E8E2C73F5264A861C41493D8238 /* AvoNull.h */,
-				20D6FCC49D0C393926D9075D663628B6 /* AvoNull.m */,
-				47F46E7E2A83F59389AB4F37443FF89A /* AvoObject.h */,
-				8F66215985DAEABCF94FEA07E35F2641 /* AvoObject.m */,
-				4E874ECE0A24B5C627147DA932F29C1F /* AvoString.h */,
-				3ABA70C68A06163DB0CD69AC993324F9 /* AvoString.m */,
-				A9E9475BC83D816365989EC0B6C35DE6 /* AvoUnknownType.h */,
-				038D6C236EA84CB213BFA90D9AD16A81 /* AvoUnknownType.m */,
-			);
-			name = eventschematypes;
-			path = AvoInspector/Classes/eventschematypes;
-			sourceTree = "<group>";
-		};
 		20DE0B4C9A775BB00BED43C9FAE6A580 /* SwiftSupport */ = {
 			isa = PBXGroup;
 			children = (
@@ -1036,58 +1024,46 @@
 			name = Pods;
 			sourceTree = "<group>";
 		};
-		4AF535BE3E12317D961E942FBA08BF96 /* AvoInspector */ = {
+		32647E0F34F746C21DFE0CFA6CD18C7D /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				A9F3578ABD4F65B3E5BCB1CEE7092373 /* AvoAnonymousId.h */,
-				8084EB7CFDB784609B9228960BD5E14A /* AvoAnonymousId.m */,
-				6ECD35C03E8AE0C97FEC4F507D20A892 /* AvoBatcher.h */,
-				CE4E03A6152FD02F67111E49C036B2E2 /* AvoBatcher.m */,
-				BFF320C496B06A51EE9AF62FD9F939BF /* AvoDeduplicator.h */,
-				E1E2556DB4880FEA7020412FFB9670A1 /* AvoDeduplicator.m */,
-				D2B0A62A430CB996421976D614FE9F47 /* AvoEventSpecCache.h */,
-				D522AA9D98D2EFB77EC6371A3E73D6E8 /* AvoEventSpecCache.m */,
-				D4C222E409A85E689ED2359DD9FE5245 /* AvoEventSpecFetcher.h */,
-				11E61668DA3D1777A073E4401EC884A9 /* AvoEventSpecFetcher.m */,
-				1AAD8ECBAF0BA9FA35ECFBB212D21ACF /* AvoEventSpecFetchTypes.h */,
-				99805C28CAC664ED729B1456ED867815 /* AvoEventSpecFetchTypes.m */,
-				0C743BD8948F4C76B052292B1D33ED6F /* AvoEventValidator.h */,
-				4F2597E1BF960E93C626856E681C6926 /* AvoEventValidator.m */,
-				9F72FE2576CBFDB3DA6ED0E0B751F289 /* AvoGuid.h */,
-				B53B03FE51473DF05F79B4A61BA3C381 /* AvoGuid.m */,
-				578C3CBB97F8DD56F18223700EFA7DE0 /* AvoInspector.h */,
-				3DA2A8E2329A2740C7293ED9D413102C /* AvoInspector.m */,
-				62636EEA0826F8656B9FA53FE4CED721 /* AvoNetworkCallsHandler.h */,
-				6BD7E9F680E4AF560BFC8074CB38F034 /* AvoNetworkCallsHandler.m */,
-				618B007074A8ADB69E39EC1F7DF7F7B4 /* AvoSchemaExtractor.h */,
-				38E7D075617A98BFF1264F9557387DBD /* AvoSchemaExtractor.m */,
-				0E782B26D2EF872071701465F10F46A8 /* AvoStorage.h */,
-				D962E8DD98717C2F4E5B56CA72930AB0 /* AvoUtils.h */,
-				CAF06CF564FB71A1B0FF2732C4014659 /* AvoUtils.m */,
-				ABCF0D077978AAB841F0BBA3F30ED727 /* Inspector.h */,
-				699C91B5CB2674B514629B0861E1D11A /* PrivacyInfo.xcprivacy */,
-				1FB7F2ED4B401F9A3D9E3AF5419D7252 /* eventschematypes */,
-				6726FB3D2E0D1CDDB6FEC7697FED253F /* Pod */,
-				501DBCA0ECC4A6EDAF74ED45C7BECBD4 /* Support Files */,
-			);
-			name = AvoInspector;
-			path = ../..;
-			sourceTree = "<group>";
-		};
-		501DBCA0ECC4A6EDAF74ED45C7BECBD4 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				D146E811960E58664C00916F1D264AC5 /* AvoInspector.modulemap */,
-				F822A7A01960459C00E77F4AB5923A81 /* AvoInspector-dummy.m */,
-				FFD0123BA1BEE2B87FF68A6650E61219 /* AvoInspector-Info.plist */,
-				D1FBE712CE2C234BD94FF6A5D830E36A /* AvoInspector-prefix.pch */,
-				203A5D32352BD7C0791FD153F5930FE8 /* AvoInspector-umbrella.h */,
-				99C83184B0AF5E532B2101A5C36DFAAD /* AvoInspector.debug.xcconfig */,
-				3741DA3456746B34C0C805196EEB5725 /* AvoInspector.release.xcconfig */,
-				BA44CED3073504D76FD4B66BA0BB9260 /* ResourceBundle-AvoInspector-AvoInspector-Info.plist */,
+				6250DFC2EA838D81BF29ECC30970D1AD /* AvoInspector.modulemap */,
+				D356E6789FFA488A8D25A1DF6958C45B /* AvoInspector-dummy.m */,
+				2F62F3ABCD572CA0A4B9F6D4478EE3D5 /* AvoInspector-Info.plist */,
+				3BDD30A1C84B7DA2C3E27B7A6B6CCEB5 /* AvoInspector-prefix.pch */,
+				9CDA5569773A911B202D725A6F48C164 /* AvoInspector-umbrella.h */,
+				FD323F46B9B5AE0A51E0DA88761CC07D /* AvoInspector.debug.xcconfig */,
+				97703A195D2DE48F1EAAE3817B59AA8E /* AvoInspector.release.xcconfig */,
+				BEC87A3F51FB9891C52014745531E9A8 /* ResourceBundle-AvoInspector-AvoInspector-Info.plist */,
 			);
 			name = "Support Files";
 			path = "Example/Pods/Target Support Files/AvoInspector";
+			sourceTree = "<group>";
+		};
+		3DA1417B96522673A23CD82E267D924B /* eventschematypes */ = {
+			isa = PBXGroup;
+			children = (
+				26741524D48E0D50E4330AF36CD60097 /* AvoBoolean.h */,
+				DDC8740D93D55A37485D5696466F8FF6 /* AvoBoolean.m */,
+				790F5219355A902DED1E675EADFC01D8 /* AvoEventSchemaType.h */,
+				39D40952AB64E5374262554E98BE6A6F /* AvoEventSchemaType.m */,
+				1FEDD12D0E95E06CDA3A818F48C93AE6 /* AvoFloat.h */,
+				2E0378F169A2652F65528D95369711E5 /* AvoFloat.m */,
+				7E3234141BC0E991DA41BAD84FF304C0 /* AvoInt.h */,
+				B315AD2E8094367F5673EA0654B86644 /* AvoInt.m */,
+				4EF29B41E096F8698DD5C733AA6699CF /* AvoList.h */,
+				929B9AA67483862EEB4B5FA238D2DB15 /* AvoList.m */,
+				BFE9216CA56AE869328FE543F9533EBC /* AvoNull.h */,
+				3B6A9A5E885251E18289D77441F99C23 /* AvoNull.m */,
+				F1AF6F5996B72F2B43C2000663A91424 /* AvoObject.h */,
+				4B915E7F7FECA66AF5CC22E749A71230 /* AvoObject.m */,
+				BDEA666C356BE70AD8AA26F5A151EB15 /* AvoString.h */,
+				F1FADC3424633DA8A2362EF57E408A86 /* AvoString.m */,
+				7724BA2B5BCF55DA67AF6871B5C2AC1F /* AvoUnknownType.h */,
+				85A7ABFC918C7DAED63625F2BD0B12DA /* AvoUnknownType.m */,
+			);
+			name = eventschematypes;
+			path = AvoInspector/Classes/eventschematypes;
 			sourceTree = "<group>";
 		};
 		530247586260EB038A501D034F0C005C /* Support Files */ = {
@@ -1150,24 +1126,6 @@
 			path = "Expecta+Snapshots";
 			sourceTree = "<group>";
 		};
-		60D22C3C8BB847046813DE8C66A7AA7D /* Development Pods */ = {
-			isa = PBXGroup;
-			children = (
-				4AF535BE3E12317D961E942FBA08BF96 /* AvoInspector */,
-			);
-			name = "Development Pods";
-			sourceTree = "<group>";
-		};
-		6726FB3D2E0D1CDDB6FEC7697FED253F /* Pod */ = {
-			isa = PBXGroup;
-			children = (
-				A99C63629A66DBC947FF078AFB7A7F14 /* AvoInspector.podspec */,
-				15E6B1A5201E540D50D44A8EA6814764 /* LICENSE */,
-				95B33555E3C4E808A8893BDDED3627AD /* README.md */,
-			);
-			name = Pod;
-			sourceTree = "<group>";
-		};
 		69D2DB74B8C3EA0844371B6DAC1FD640 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
@@ -1196,6 +1154,46 @@
 			);
 			name = "Support Files";
 			path = "../Target Support Files/FBSnapshotTestCase";
+			sourceTree = "<group>";
+		};
+		790DFF98F14C8C1BC675AA85CD3388F9 /* AvoInspector */ = {
+			isa = PBXGroup;
+			children = (
+				F25FC41FBBB86BB5B909408B73977416 /* AvoAnonymousId.h */,
+				8712A08613885978559646EB7F0574EF /* AvoAnonymousId.m */,
+				ADD074A6D2F56D7995D2A20543DADB67 /* AvoBatcher.h */,
+				C14985C09E15E0916D142E841B41BE0F /* AvoBatcher.m */,
+				E732305A85BEB916577CA35320C790BD /* AvoDeduplicator.h */,
+				1B074C672344ACE03111514BD1434E42 /* AvoDeduplicator.m */,
+				B13924B2208998F2F0E3C632E8AB9E03 /* AvoEncryption.h */,
+				7277418CA65ABAD91856DBC474B383C3 /* AvoEncryption.m */,
+				ED61FDE0E154F68B00CA7E96CD8BEDE2 /* AvoEventSpecCache.h */,
+				379BA466768D48F013EE1EA03D708DB2 /* AvoEventSpecCache.m */,
+				6B6952669D99AC3C1505393E9E81F91E /* AvoEventSpecFetcher.h */,
+				2399E226A9877FA4E9CA3119E64790CF /* AvoEventSpecFetcher.m */,
+				92CB4D38795C5907816E28F955B48160 /* AvoEventSpecFetchTypes.h */,
+				EC2E169879776C38C36D0887B44E3213 /* AvoEventSpecFetchTypes.m */,
+				B2C3DBD54E74DFE6F68A326C4C73C41A /* AvoEventValidator.h */,
+				47E02A6E51EC790668D4CEB2A6DEB11F /* AvoEventValidator.m */,
+				6B1FE2AD6DEC12989C6C43975BDD1230 /* AvoGuid.h */,
+				70E6B4E2105C14C4F2273B9348DC30C8 /* AvoGuid.m */,
+				59B03BE100305444A2C4AA46124C532D /* AvoInspector.h */,
+				E9700210CA98FDE33B1696F43A998E1B /* AvoInspector.m */,
+				C3F0FB594533465FEFC208DE37070108 /* AvoNetworkCallsHandler.h */,
+				978C57D230C03D13B4B87709F074A17D /* AvoNetworkCallsHandler.m */,
+				1FFBEE081D2873A076F7BC3DFD9593AE /* AvoSchemaExtractor.h */,
+				2D00522674DC08BC7BE6DC6822ED1E5F /* AvoSchemaExtractor.m */,
+				2E1EB07A2558B365D82EC9A5DE4CE430 /* AvoStorage.h */,
+				58F22A3684E27B3119E9C19B6068EE35 /* AvoUtils.h */,
+				DB0FCD211D625E73AB05085B50615ADA /* AvoUtils.m */,
+				D5379B80E1DFF854F55F4AF937493F3F /* Inspector.h */,
+				0C25C5555B918DA65963EBD41EF2550F /* PrivacyInfo.xcprivacy */,
+				3DA1417B96522673A23CD82E267D924B /* eventschematypes */,
+				080D05E07C6B279DA4A7E3A8950D0660 /* Pod */,
+				32647E0F34F746C21DFE0CFA6CD18C7D /* Support Files */,
+			);
+			name = AvoInspector;
+			path = ../..;
 			sourceTree = "<group>";
 		};
 		8267B9022F058E7F7A69338B2BE79344 /* iOS */ = {
@@ -1461,12 +1459,20 @@
 			isa = PBXGroup;
 			children = (
 				9D940727FF8FB9C785EB98E56350EF41 /* Podfile */,
-				60D22C3C8BB847046813DE8C66A7AA7D /* Development Pods */,
+				DE4168233452F807BEC878EF32243CD2 /* Development Pods */,
 				B94D7768568A9992200DB461E8CF687F /* Frameworks */,
 				2F9AEC66122BFDC5448B3E8D3B8D827D /* Pods */,
 				A7F7EDC3CEE3D87D76A39C2A96395FE8 /* Products */,
 				23422A3A793A2E9457BE2DF868CF8C14 /* Targets Support Files */,
 			);
+			sourceTree = "<group>";
+		};
+		DE4168233452F807BEC878EF32243CD2 /* Development Pods */ = {
+			isa = PBXGroup;
+			children = (
+				790DFF98F14C8C1BC675AA85CD3388F9 /* AvoInspector */,
+			);
+			name = "Development Pods";
 			sourceTree = "<group>";
 		};
 		F3F1D3991FAE800945FB0E11C4655D61 /* Support Files */ = {
@@ -1532,6 +1538,38 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		266B63A762C4A3DD3F94BAAA895ECD06 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AA1838E30D21D2BD2122B3E3808BBE74 /* AvoAnonymousId.h in Headers */,
+				819972C44694E9A918C9BA7FF20A04DE /* AvoBatcher.h in Headers */,
+				ED5BDC6CC5E5F21AA4CBFA4C642AEA12 /* AvoBoolean.h in Headers */,
+				403FC20C73363BFAB802F070FC0BAB90 /* AvoDeduplicator.h in Headers */,
+				C934FD8637050CD8CA03F50519F869C9 /* AvoEncryption.h in Headers */,
+				F0E1AE4D6053107DC0CC6D2E753BA4DC /* AvoEventSchemaType.h in Headers */,
+				B95E8D8762F309A4E28A6718E4963654 /* AvoEventSpecCache.h in Headers */,
+				FFB7AD928D101647F76080BC6D0DCB5A /* AvoEventSpecFetcher.h in Headers */,
+				6AA117C5CE53562773840CB83BB3F06E /* AvoEventSpecFetchTypes.h in Headers */,
+				7DE588F368488DC94290965EE02CE9CE /* AvoEventValidator.h in Headers */,
+				437B538A1E68D0D267EF463CBFC465A2 /* AvoFloat.h in Headers */,
+				23E708790314D7A959DBF4BF47B63FD8 /* AvoGuid.h in Headers */,
+				74E44A604797A9F902C0F812501A7C75 /* AvoInspector.h in Headers */,
+				5B500DB71E67ECF02498B0FB1A1D90FA /* AvoInspector-umbrella.h in Headers */,
+				B3585B3B5FFA3917A1008448D4413564 /* AvoInt.h in Headers */,
+				0945F210CA2FA0ADD947001B34626A1F /* AvoList.h in Headers */,
+				4D6A36F9271F6D8FC9CBED7F9461FB69 /* AvoNetworkCallsHandler.h in Headers */,
+				4F7C81475B9B45A70B7B87859FBB9291 /* AvoNull.h in Headers */,
+				19728061FA1AB24A36AA644F34B98447 /* AvoObject.h in Headers */,
+				78AFD64E8328157CB1030F08D004318E /* AvoSchemaExtractor.h in Headers */,
+				5042D6A9ECD7BA222DB1C809B0FC77E1 /* AvoStorage.h in Headers */,
+				9D7BFA8A8C19DC1765E7FCE3CE5F4F36 /* AvoString.h in Headers */,
+				3CAA15491A5B2E0B1EE0A54C428E8A65 /* AvoUnknownType.h in Headers */,
+				888E52DEBEDFD4AD6953C99D59071F68 /* AvoUtils.h in Headers */,
+				4EA2DE04B78116EA8FDA647667496162 /* Inspector.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		294ADB17E86A2BB02C356F8B8D8200C4 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -1579,57 +1617,41 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		4A01F05A921774364E400B8135EFA806 /* Headers */ = {
+		87DC2281917BA98A42C6163440F6BAA5 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4517240D81F46D7837453CF7D900DB67 /* Specta.h in Headers */,
-				9637ED83FED5E1902B8F86D08FE20DC7 /* Specta-umbrella.h in Headers */,
-				89074D6A1FA4312859BE575CE840228D /* SpectaDSL.h in Headers */,
-				C0B0F28C4C39773CB8065AFDDF3760B7 /* SpectaTypes.h in Headers */,
-				7C09D4723035233E8F0F07EC7AD2D17C /* SpectaUtility.h in Headers */,
-				836D31E00E8795CFEE0CDC534DD025F2 /* SPTCallSite.h in Headers */,
-				FDC9C7C3BA26AB839EA90759E0F66CB7 /* SPTCompiledExample.h in Headers */,
-				8551BE8E0F918616FCF7F022FE443958 /* SPTExample.h in Headers */,
-				80A5F6391A250DF910FC2F611948E9F1 /* SPTExampleGroup.h in Headers */,
-				ED3119D15C7377DE48D0AC2D9D3069FA /* SPTExcludeGlobalBeforeAfterEach.h in Headers */,
-				1B5715568646C78FC28AE6B490E2715D /* SPTGlobalBeforeAfterEach.h in Headers */,
-				CF6DE4AD8CA4138A9E0DD07EACECBE38 /* SPTSharedExampleGroups.h in Headers */,
-				FA77FA431CDFE32702DF32E2A5CF4A64 /* SPTSpec.h in Headers */,
-				40B87962E9D7D89B2BE425367DE82457 /* SPTTestSuite.h in Headers */,
-				6FB4D5569ABC35CCA8C236D1B8F15139 /* XCTest+Private.h in Headers */,
-				7F7292C50FFB369954E7E93178CEAF78 /* XCTestCase+Specta.h in Headers */,
+				D70A4864E756F0908A7D7D4CEDDC298D /* Specta.h in Headers */,
+				E7ECFB4B7F9F5E9B918211100D5FF688 /* Specta-umbrella.h in Headers */,
+				4A4529E44836A05DA1F37F7A72FAEA40 /* SpectaDSL.h in Headers */,
+				53C3ACEEA2B33E51AF1CDCD9D6BF257D /* SpectaTypes.h in Headers */,
+				5EC8C5EFF9F57C8B48B1C4A82D2B2AAF /* SpectaUtility.h in Headers */,
+				F05F1B346679EFADA14BF111F0C0E9E9 /* SPTCallSite.h in Headers */,
+				96172600BE9FA960A255DBDFA80682B8 /* SPTCompiledExample.h in Headers */,
+				7B490722589857374E21E3F6D9F783A6 /* SPTExample.h in Headers */,
+				CE6A4A4415CBEECD9B0802185C831AEC /* SPTExampleGroup.h in Headers */,
+				40472AB3D35234CAEBE2E3FD23A56A8D /* SPTExcludeGlobalBeforeAfterEach.h in Headers */,
+				4D9AE087718E3550648C2F1DC73466BB /* SPTGlobalBeforeAfterEach.h in Headers */,
+				25BBF9AF6A935A06F5ADD8CB5EFBDE26 /* SPTSharedExampleGroups.h in Headers */,
+				6937C9A85FFD690DE4A83FF5C2BD8F88 /* SPTSpec.h in Headers */,
+				C5625F28A4BD1D02CD0EC442257B02C4 /* SPTTestSuite.h in Headers */,
+				769096945F6486DCD3F3E684E52FC9A8 /* XCTest+Private.h in Headers */,
+				7EFB8CF844CCA75397332B13F04133EF /* XCTestCase+Specta.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		6CED5624D77D4C9241FE5653DC16971E /* Headers */ = {
+		8B64049355ED9736973ACFC360AB9CFF /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				95F28E20A36FA4D3BDF77FB3BD760840 /* AvoAnonymousId.h in Headers */,
-				A770586D91E2AE41ED8D4D1AE83E1B5F /* AvoBatcher.h in Headers */,
-				802E4069023C9A6BA9457A77D0C2AF9F /* AvoBoolean.h in Headers */,
-				F7A5A517F200011A95C99F6D97672277 /* AvoDeduplicator.h in Headers */,
-				9A8705085F37B28DBEA6CDDE34847509 /* AvoEventSchemaType.h in Headers */,
-				DA1D01E35623C4C8EAC266A4D3D2285A /* AvoEventSpecCache.h in Headers */,
-				075E4C3FF276BFDB86820DE962CDBB1F /* AvoEventSpecFetcher.h in Headers */,
-				62972A2604C4C9CCEB6EA2A68CF7E196 /* AvoEventSpecFetchTypes.h in Headers */,
-				7D6855F7809E71FBBDF11E8642352B2B /* AvoEventValidator.h in Headers */,
-				867AFF556CF5DBDDECE208413A08FE51 /* AvoFloat.h in Headers */,
-				C4B6F5134FD079F5D06C578E71F6C4F3 /* AvoGuid.h in Headers */,
-				DCC00F6470D24363047ED63F62C375E0 /* AvoInspector.h in Headers */,
-				AB005363F8859BE8055967763BDAFD03 /* AvoInspector-umbrella.h in Headers */,
-				3595E26C063B290D9547DD576597FA02 /* AvoInt.h in Headers */,
-				AB5B5027D6BD6DD75F1FFC0352C4D90F /* AvoList.h in Headers */,
-				349E64192EE5F700FFB9AEBFC60F60F6 /* AvoNetworkCallsHandler.h in Headers */,
-				8B760AE16665910CA173A2F4F71C10CA /* AvoNull.h in Headers */,
-				1A195F1D4B04A025A5CB588DC08BFAE9 /* AvoObject.h in Headers */,
-				7872D01839F3B488693D15EF1D4484DC /* AvoSchemaExtractor.h in Headers */,
-				43ECD6B4249D68E3079A5E03A04E7E45 /* AvoStorage.h in Headers */,
-				032B3FA68D7AD53A3EE6F2459A0EB0DA /* AvoString.h in Headers */,
-				144C85681813A481F265F1BEB5134249 /* AvoUnknownType.h in Headers */,
-				A3A3DDB0FD9423F3250C907147ED14F9 /* AvoUtils.h in Headers */,
-				EC85FC77E03DB3D8F30933360F3ED06B /* Inspector.h in Headers */,
+				51CABC8AD6F121D6DC9B55E04AFE23B0 /* FBSnapshotTestCase.h in Headers */,
+				D923FCA29609D01B0CAB584D443842A8 /* FBSnapshotTestCase-umbrella.h in Headers */,
+				D0F28A394E5CDC4EB3167894D88C579F /* FBSnapshotTestCasePlatform.h in Headers */,
+				0083550F521381651B3DA6C7ADC2FB7E /* FBSnapshotTestController.h in Headers */,
+				FA7F793719AA7D6E40414E3ECD2E74FD /* UIApplication+StrictKeyWindow.h in Headers */,
+				4C64315AFD11527D11C76667A29C140E /* UIImage+Compare.h in Headers */,
+				5BDF4E14FFEA4707A68E8814AF0B990A /* UIImage+Diff.h in Headers */,
+				C95B4CE8A5A98F46480FA48E56C8EBA4 /* UIImage+Snapshot.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1679,21 +1701,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		C69D77E35F344B8B2BD19019B1F813C8 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				0C0D31B3765120C19ED0CB98924B5EF2 /* FBSnapshotTestCase.h in Headers */,
-				1E0329DF5BAF0EFAE5A97C82CC9B86AF /* FBSnapshotTestCase-umbrella.h in Headers */,
-				4B5DEF09462A94DC2BDB4B21C06D6B9F /* FBSnapshotTestCasePlatform.h in Headers */,
-				47C488EC9FBC5842632D7E64AEF82A94 /* FBSnapshotTestController.h in Headers */,
-				3AD206F8263B9E091EC800594666F2B6 /* UIApplication+StrictKeyWindow.h in Headers */,
-				3E40BCF4A7388DF5ED3C574A4D41065B /* UIImage+Compare.h in Headers */,
-				9929E370BD645542D699663D22550085 /* UIImage+Diff.h in Headers */,
-				BD68436CB0DC061FD63C93E650217F8D /* UIImage+Snapshot.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		D83428F0D522F78147E11FA44DB84A74 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -1715,17 +1722,17 @@
 /* Begin PBXNativeTarget section */
 		5CB07DC335904D6A8475653674C0BF14 /* AvoInspector */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = D2261DF368ABC18459ED32B32E944829 /* Build configuration list for PBXNativeTarget "AvoInspector" */;
+			buildConfigurationList = 86DCBDD365BC533ADFCE308B9FCD5250 /* Build configuration list for PBXNativeTarget "AvoInspector" */;
 			buildPhases = (
-				6CED5624D77D4C9241FE5653DC16971E /* Headers */,
-				8BE984C03DAAA71789B7BCD9BE39A48E /* Sources */,
-				7434F97D1554119021448756C5C716FB /* Frameworks */,
-				77BF4D641E266092AAEA0E9D336A792C /* Resources */,
+				266B63A762C4A3DD3F94BAAA895ECD06 /* Headers */,
+				DC1D50CA73EA59FC3FD5FC286A7DCBD6 /* Sources */,
+				DEF42948920BE1D2BE7C97D6741731FE /* Frameworks */,
+				1FF6E6CBE7E38205BF28D3A5AC6F69CF /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				A4A88AAAE4DC067FEBB626CD1A5A629B /* PBXTargetDependency */,
+				368FB64124652842EECCC6E7A283C631 /* PBXTargetDependency */,
 			);
 			name = AvoInspector;
 			productName = AvoInspector;
@@ -1744,8 +1751,8 @@
 			buildRules = (
 			);
 			dependencies = (
-				8E206F1703CD43DD7792ABE2E95D3EAB /* PBXTargetDependency */,
-				A9EC7387E957C26879F9E2A1755089E1 /* PBXTargetDependency */,
+				5144768AF7004E8280981481B722969E /* PBXTargetDependency */,
+				EFEA5604F40548F9F62BAE9224C6920F /* PBXTargetDependency */,
 			);
 			name = "Pods-AvoStateOfTracking_Example";
 			productName = Pods_AvoStateOfTracking_Example;
@@ -1764,9 +1771,9 @@
 			buildRules = (
 			);
 			dependencies = (
-				2BEA8B1AC3063D81198865E72937E1B4 /* PBXTargetDependency */,
-				133F7F539EF27295744D83F1BFB9FC7C /* PBXTargetDependency */,
-				7D04D9E2024E261698B3D19D46AA37F4 /* PBXTargetDependency */,
+				E3E606868D57932AB079DE3CBAF1989A /* PBXTargetDependency */,
+				3D6CFB8F9C437C1CB6A08273D65C0C50 /* PBXTargetDependency */,
+				E7ABC07C9556ABD15016A49A2594013B /* PBXTargetDependency */,
 			);
 			name = "Expecta+Snapshots";
 			productName = Expecta_Snapshots;
@@ -1803,12 +1810,12 @@
 			buildRules = (
 			);
 			dependencies = (
-				87D38E041E4D927E9621A147ADF5D713 /* PBXTargetDependency */,
-				255F12B795E81B7C0B7603C403791A05 /* PBXTargetDependency */,
-				179D6F4BA67DD88DEBA6D5A71539D56F /* PBXTargetDependency */,
-				074111FAE755D1E7DCDB7F31C22AA289 /* PBXTargetDependency */,
-				C9B71E5C10B6913A437E7D73538FCE0B /* PBXTargetDependency */,
-				8A4A4CFE6D8FC4EEFB0AE4DF0F9BFFB2 /* PBXTargetDependency */,
+				F9249E9E08150332DEE1B5658DE1B8E9 /* PBXTargetDependency */,
+				D0E4D6F4E56B1D470F6BB56EC744ADE4 /* PBXTargetDependency */,
+				3DCA494A0201E7352F5105A7999331AE /* PBXTargetDependency */,
+				E44667C4D530AB232128F7AE1C11AC4B /* PBXTargetDependency */,
+				090505548CE37251E622EDB697E042B9 /* PBXTargetDependency */,
+				4F3DB01935D7FCF753E1136895662307 /* PBXTargetDependency */,
 			);
 			name = "Pods-AvoStateOfTracking_Tests";
 			productName = Pods_AvoStateOfTracking_Tests;
@@ -1817,12 +1824,12 @@
 		};
 		98A98149697C80CEF8D5772791E92E66 /* FBSnapshotTestCase */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 1E24822850917E0A4CA99EA0DC08A2FC /* Build configuration list for PBXNativeTarget "FBSnapshotTestCase" */;
+			buildConfigurationList = DAAB846307E594BE918FB931DA2F392E /* Build configuration list for PBXNativeTarget "FBSnapshotTestCase" */;
 			buildPhases = (
-				C69D77E35F344B8B2BD19019B1F813C8 /* Headers */,
-				9298FF2A5E1ED76C3EFD00FFC4208DB1 /* Sources */,
-				5F231B0357D58A815A72D47D2A290AC4 /* Frameworks */,
-				AF354E24439CFD5E6FFD2529024E9354 /* Resources */,
+				8B64049355ED9736973ACFC360AB9CFF /* Headers */,
+				2DB5AEFF6A5B0A9F6F7FA94207F25605 /* Sources */,
+				C654922FDC41B3F3BDBEE8B479262A8C /* Frameworks */,
+				E7AB62962F9A03368773899DC52EB753 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -1871,11 +1878,11 @@
 		};
 		F4C762008BED3853BA2FF0F9CF0C3D6D /* AvoInspector-AvoInspector */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 8FB5C638F93C0F43B147FD7E47446807 /* Build configuration list for PBXNativeTarget "AvoInspector-AvoInspector" */;
+			buildConfigurationList = E50FCFE0A34CFF32746710256F56DEA2 /* Build configuration list for PBXNativeTarget "AvoInspector-AvoInspector" */;
 			buildPhases = (
-				206D940CC100B84E1CF89A471E15161E /* Sources */,
-				AF76CDA69BF30B885282A990096F16C3 /* Frameworks */,
-				3ABF50092776AE9348CA4AD039AEEDC1 /* Resources */,
+				6D5D6157E14736C484000CB2515ACF74 /* Sources */,
+				0D86C9EAF2455DD7BEA3BD4847FB8017 /* Frameworks */,
+				14554DC4152D02F1539F93DE363F102F /* Resources */,
 			);
 			buildRules = (
 			);
@@ -1888,12 +1895,12 @@
 		};
 		F8676010755CF1530FC02DA9A0D8822B /* Specta */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = E57921E81D6CA7C1B80D1725EE58663D /* Build configuration list for PBXNativeTarget "Specta" */;
+			buildConfigurationList = 4AFA804C77CBCEB6F634A1614BC2E227 /* Build configuration list for PBXNativeTarget "Specta" */;
 			buildPhases = (
-				4A01F05A921774364E400B8135EFA806 /* Headers */,
-				76FC0FB3CC78F63776BE45A158ED7753 /* Sources */,
-				A2D0103A6FD629C3FE0463813D6C2D6C /* Frameworks */,
-				998182F9DB11B8AFC826C56A2D5529CF /* Resources */,
+				87DC2281917BA98A42C6163440F6BAA5 /* Headers */,
+				49BD8F6D7C3C553213393EFD2C08E905 /* Sources */,
+				989DCC880C95F320026AFFDDC69F4117 /* Frameworks */,
+				6A5C064EC6D3A3B06989A096BE0D5AE7 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -1943,11 +1950,19 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		3ABF50092776AE9348CA4AD039AEEDC1 /* Resources */ = {
+		14554DC4152D02F1539F93DE363F102F /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				044B1562D28200AE1ADF52860F50581A /* PrivacyInfo.xcprivacy in Resources */,
+				F1F05CD4858A27EA49278F554AA00CBD /* PrivacyInfo.xcprivacy in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1FF6E6CBE7E38205BF28D3A5AC6F69CF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C7F048E0D6358714F4E0C2378CF6D7A8 /* AvoInspector-AvoInspector in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1965,6 +1980,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		6A5C064EC6D3A3B06989A096BE0D5AE7 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		73DBD5FF1751F79FF064FE98BB02137E /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1972,29 +1994,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		77BF4D641E266092AAEA0E9D336A792C /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				9579B61D8CD4258E912A3190C5239C7A /* AvoInspector-AvoInspector in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		89206AB21C948941522C51F06099748B /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		998182F9DB11B8AFC826C56A2D5529CF /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		AF354E24439CFD5E6FFD2529024E9354 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2015,16 +2015,16 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-/* End PBXResourcesBuildPhase section */
-
-/* Begin PBXSourcesBuildPhase section */
-		206D940CC100B84E1CF89A471E15161E /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
+		E7AB62962F9A03368773899DC52EB753 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
 		267447355F3F66EFBFA6A83C206EFAF6 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2056,6 +2056,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		2DB5AEFF6A5B0A9F6F7FA94207F25605 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				69AD7AC53FA616AB049BC3A8982A9551 /* FBSnapshotTestCase.m in Sources */,
+				BC781426400DB88530D0BD9E79B933F4 /* FBSnapshotTestCase-dummy.m in Sources */,
+				4BCBE0C02E55B339599BA97EE73192D6 /* FBSnapshotTestCasePlatform.m in Sources */,
+				4708123091267CBFC1B72D552F425DAD /* FBSnapshotTestController.m in Sources */,
+				5AA24B90FB7B773E77CDD179E9A7D2D0 /* SwiftSupport.swift in Sources */,
+				5040F523403BF08DB74ECA75991FC8AE /* UIApplication+StrictKeyWindow.m in Sources */,
+				1F71132F5B315D42EFEC30A4A8CAFAB5 /* UIImage+Compare.m in Sources */,
+				6312C927DDF10CD4C35E3149D6B4F6ED /* UIImage+Diff.m in Sources */,
+				9F9B59978C33C9BEDAB2C94B1CBC77B8 /* UIImage+Snapshot.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		3F33631F1EA88F5DCF8E9CF6E185C038 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2063,6 +2079,31 @@
 				6ACBAB7981C7E257408E7A452D46E411 /* Expecta+Snapshots-dummy.m in Sources */,
 				EEF975FF4A1C7534532877EDE56C68CE /* ExpectaObject+FBSnapshotTest.m in Sources */,
 				2C8296EEF1C05BA808C028E89BAC669B /* EXPMatchers+FBSnapshotTest.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		49BD8F6D7C3C553213393EFD2C08E905 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				016E585A9773A577C64A433B8DB6E19E /* Specta-dummy.m in Sources */,
+				2DF6F1296C0961D4FB6E638978EDE21C /* SpectaDSL.m in Sources */,
+				CC87EB046273A8816C46B1A537175D2C /* SpectaUtility.m in Sources */,
+				126E46FE3404804E3F8DD2CDC0B5B4E8 /* SPTCallSite.m in Sources */,
+				06C0985E9C1A152C93E8F10787898EB2 /* SPTCompiledExample.m in Sources */,
+				F796EC4896C454D173A105FE87F99819 /* SPTExample.m in Sources */,
+				E318FBE2E27689B23DA771B8B0520CFB /* SPTExampleGroup.m in Sources */,
+				9569C8C2A2DC4DF5062E8526D1925715 /* SPTSharedExampleGroups.m in Sources */,
+				F05516502B0EF2C395D3ABAF16AA5587 /* SPTSpec.m in Sources */,
+				8B45D9E27E775DCA16600B63F4EE70E5 /* SPTTestSuite.m in Sources */,
+				01C229CAFF9272677D1ACC7AD06C583C /* XCTestCase+Specta.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6D5D6157E14736C484000CB2515ACF74 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2074,74 +2115,41 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		76FC0FB3CC78F63776BE45A158ED7753 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				EEA09BA7827B978EC01A8A24F73137FC /* Specta-dummy.m in Sources */,
-				24A599BD3012C748C8AF1FD11361F528 /* SpectaDSL.m in Sources */,
-				87F08355A3AA6F9E8185E83D5C104F32 /* SpectaUtility.m in Sources */,
-				0289329B60AFF8EBB8B5A432EFC4978D /* SPTCallSite.m in Sources */,
-				0EA2F6B96D7A46FB7CDA648F57EE98B3 /* SPTCompiledExample.m in Sources */,
-				FB7895E3A17915DDEDB4A14E01398F5D /* SPTExample.m in Sources */,
-				7CD4FEA89658341CF06CC1860F8B79E5 /* SPTExampleGroup.m in Sources */,
-				830F1FEDE8892C0157D17F8DFF9BF050 /* SPTSharedExampleGroups.m in Sources */,
-				8D43EAA8C65497B48185F4674AE1BDAD /* SPTSpec.m in Sources */,
-				451C399D2C466248D51DFBC0C2170C77 /* SPTTestSuite.m in Sources */,
-				2439A0A6F5C2E0CF42A69A23018B7820 /* XCTestCase+Specta.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		8BE984C03DAAA71789B7BCD9BE39A48E /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				51712B47CD40E8B488EB44FD692E5D6F /* AvoAnonymousId.m in Sources */,
-				A315A4DEA0CC1A85F46428EEA67DB97D /* AvoBatcher.m in Sources */,
-				2EBC4CFE193EBF26B810F8564FDBC8E8 /* AvoBoolean.m in Sources */,
-				E95D020AD4A525AA413772AC2D49031D /* AvoDeduplicator.m in Sources */,
-				8335B811CC809CB23F8F65C6D0687D73 /* AvoEventSchemaType.m in Sources */,
-				B6403AF5D22BA28CED164B26F5554F70 /* AvoEventSpecCache.m in Sources */,
-				8592821A266BBE92414F120040F7C62E /* AvoEventSpecFetcher.m in Sources */,
-				92147AF800B0E921BBEA0ED66B03D4CC /* AvoEventSpecFetchTypes.m in Sources */,
-				FF61B28C3A64788818AE97C6C4D08B10 /* AvoEventValidator.m in Sources */,
-				B23102CA40401D61DB2F9B443455306B /* AvoFloat.m in Sources */,
-				7C3C833FEB61AF039DD17B541B33AD12 /* AvoGuid.m in Sources */,
-				85B35C43735F4700EFCEE5B6B2CABDB2 /* AvoInspector.m in Sources */,
-				2E137A02EC19518FEFB306C8C95157EB /* AvoInspector-dummy.m in Sources */,
-				A31FA4FFCB410754EF1D804E2B9056E3 /* AvoInt.m in Sources */,
-				B9A1EDCEAA0A09A91E09C7198DE0C675 /* AvoList.m in Sources */,
-				76E098596DEDDF7784244C28C15AC624 /* AvoNetworkCallsHandler.m in Sources */,
-				920B90B6A59F9A8A85D1E143FB28C48F /* AvoNull.m in Sources */,
-				43758840B84246A4E7F02794BF2D938E /* AvoObject.m in Sources */,
-				6DFEB71D8F43B37AE2BFD5A07DAE8B94 /* AvoSchemaExtractor.m in Sources */,
-				EC1F0445B4E9A345D6A6339AD26B107A /* AvoString.m in Sources */,
-				D901773AF07AAC5235D25134E2D887CD /* AvoUnknownType.m in Sources */,
-				7C8160F46148AB5574413DE76522B28F /* AvoUtils.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		9298FF2A5E1ED76C3EFD00FFC4208DB1 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				A0C2195558BF4AF19587BADAEF2A181D /* FBSnapshotTestCase.m in Sources */,
-				5C9F8854FFBF5719D03A883A008F7C52 /* FBSnapshotTestCase-dummy.m in Sources */,
-				87A26817ADACD3FDF4A346212C5819F6 /* FBSnapshotTestCasePlatform.m in Sources */,
-				23247ABB3C58D4411D6F0598CF136FD3 /* FBSnapshotTestController.m in Sources */,
-				718B31D55E36963BC9E28AED5FCDF20B /* SwiftSupport.swift in Sources */,
-				C3A10320BF2A6B429CD948481B509FDE /* UIApplication+StrictKeyWindow.m in Sources */,
-				8D3163817D51651D15191DF2ACE1D5C8 /* UIImage+Compare.m in Sources */,
-				99F1C7C5BBC47D7E5A78C08E139CE8CE /* UIImage+Diff.m in Sources */,
-				9FBC62DEA9A589B661A51FA3CA714996 /* UIImage+Snapshot.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		B8B1BDD7F597482399AACE515D38C34E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				3BEFC108997C4E13510E85FD1C903FE1 /* Pods-AvoStateOfTracking_Example-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DC1D50CA73EA59FC3FD5FC286A7DCBD6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				80D2F85F7A5E87010D04D42AD8173CA7 /* AvoAnonymousId.m in Sources */,
+				926086052C0CB34F547F31A55BD6890D /* AvoBatcher.m in Sources */,
+				6DAB9C1FF49654B7792C92ABB0EBF1C0 /* AvoBoolean.m in Sources */,
+				43B57611BA1383C7D520F966D19B0AE2 /* AvoDeduplicator.m in Sources */,
+				2282AFBEDF824EA49DC6CB4C3E4E2D8B /* AvoEncryption.m in Sources */,
+				296C793770EDB159E640DD9A83E86103 /* AvoEventSchemaType.m in Sources */,
+				8630C4479877E1AE249105EB84C36879 /* AvoEventSpecCache.m in Sources */,
+				6162B6EDB05F4A0A1DEB2BBFA1BC661C /* AvoEventSpecFetcher.m in Sources */,
+				432BBBF456945047CF7E4FFAC80B1D65 /* AvoEventSpecFetchTypes.m in Sources */,
+				16BC8584B24A5BE53B3B297EBE45EE7A /* AvoEventValidator.m in Sources */,
+				1E5C1BD831C5D56ECBE6E975887B6710 /* AvoFloat.m in Sources */,
+				27CD75AB87BC2CE912EF0713EDEBF3F1 /* AvoGuid.m in Sources */,
+				96C13E279BF7405C667FE59E9595EC18 /* AvoInspector.m in Sources */,
+				A5C383A380B608DA72CC9BB1E620141C /* AvoInspector-dummy.m in Sources */,
+				A597B1D316A2B53D411444403B83D104 /* AvoInt.m in Sources */,
+				02419169E760275280A83FF8C65C6612 /* AvoList.m in Sources */,
+				4B0647338C401803BE40D4E63893E394 /* AvoNetworkCallsHandler.m in Sources */,
+				ACB1BDF9839C6DD3CDAD841586738ED5 /* AvoNull.m in Sources */,
+				53DE00809F02D6C35473D18522BECF67 /* AvoObject.m in Sources */,
+				5653F37491E5FD8827D0877A63042F4F /* AvoSchemaExtractor.m in Sources */,
+				643E76C114DF2BC72F9F939C7BE03126 /* AvoString.m in Sources */,
+				02ACB111A19FB060759FAB180179BF6C /* AvoUnknownType.m in Sources */,
+				78C7133154521B8C9053B21714E533D1 /* AvoUtils.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2233,116 +2241,81 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		074111FAE755D1E7DCDB7F31C22AA289 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = OCMock;
-			target = C260B5A26D3CD54F215E5E39371483B6 /* OCMock */;
-			targetProxy = 3E9A2EB1B5E93C2B47BBCA3551FCD3DA /* PBXContainerItemProxy */;
-		};
-		133F7F539EF27295744D83F1BFB9FC7C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = FBSnapshotTestCase;
-			target = 98A98149697C80CEF8D5772791E92E66 /* FBSnapshotTestCase */;
-			targetProxy = D03EFB714C7897CB276D5EC20F8168EE /* PBXContainerItemProxy */;
-		};
-		179D6F4BA67DD88DEBA6D5A71539D56F /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = FBSnapshotTestCase;
-			target = 98A98149697C80CEF8D5772791E92E66 /* FBSnapshotTestCase */;
-			targetProxy = E6827F8C7CDD9EE68E016AE7E32670BB /* PBXContainerItemProxy */;
-		};
-		255F12B795E81B7C0B7603C403791A05 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Expecta+Snapshots";
-			target = 8B98F09738742E4D780D1B20B468CD95 /* Expecta+Snapshots */;
-			targetProxy = E10B67E9F433077F1764A0C504738D79 /* PBXContainerItemProxy */;
-		};
-		2BEA8B1AC3063D81198865E72937E1B4 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Expecta;
-			target = DC371B7477C88184274EC6710690F97C /* Expecta */;
-			targetProxy = 389541FE29DF6C0C1149AC8F8FF25E2E /* PBXContainerItemProxy */;
-		};
-		7D04D9E2024E261698B3D19D46AA37F4 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Specta;
-			target = F8676010755CF1530FC02DA9A0D8822B /* Specta */;
-			targetProxy = 6BFAEBF2637C75442D1DDA7813D5FFE9 /* PBXContainerItemProxy */;
-		};
-		87D38E041E4D927E9621A147ADF5D713 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Expecta;
-			target = DC371B7477C88184274EC6710690F97C /* Expecta */;
-			targetProxy = 1AC572E97818FF481DA6725F12F7008E /* PBXContainerItemProxy */;
-		};
-		8A4A4CFE6D8FC4EEFB0AE4DF0F9BFFB2 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Specta;
-			target = F8676010755CF1530FC02DA9A0D8822B /* Specta */;
-			targetProxy = A835733CA7530D2635CFE2137A7FB995 /* PBXContainerItemProxy */;
-		};
-		8E206F1703CD43DD7792ABE2E95D3EAB /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Analytics;
-			target = 8F50A15C556FFEAD343B69C7EA54092F /* Analytics */;
-			targetProxy = E53B50D5853CF53D71A80D338CB3089D /* PBXContainerItemProxy */;
-		};
-		A4A88AAAE4DC067FEBB626CD1A5A629B /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "AvoInspector-AvoInspector";
-			target = F4C762008BED3853BA2FF0F9CF0C3D6D /* AvoInspector-AvoInspector */;
-			targetProxy = D50B7299F7AC0BEBD8B655539EEB9F33 /* PBXContainerItemProxy */;
-		};
-		A9EC7387E957C26879F9E2A1755089E1 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = AvoInspector;
-			target = 5CB07DC335904D6A8475653674C0BF14 /* AvoInspector */;
-			targetProxy = EC70DC9235779D02B879B7CC247EE485 /* PBXContainerItemProxy */;
-		};
-		C9B71E5C10B6913A437E7D73538FCE0B /* PBXTargetDependency */ = {
+		090505548CE37251E622EDB697E042B9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Pods-AvoStateOfTracking_Example";
 			target = 86C2B19C6C53B2E2160EC2BD12330652 /* Pods-AvoStateOfTracking_Example */;
-			targetProxy = 00808B01EE7DF83275DF3399BAEEA12A /* PBXContainerItemProxy */;
+			targetProxy = EE96AE4792E0FF2D925ED992DF2B1063 /* PBXContainerItemProxy */;
+		};
+		368FB64124652842EECCC6E7A283C631 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "AvoInspector-AvoInspector";
+			target = F4C762008BED3853BA2FF0F9CF0C3D6D /* AvoInspector-AvoInspector */;
+			targetProxy = 90B90D9DF8853E983E8B4E4EE56E47A0 /* PBXContainerItemProxy */;
+		};
+		3D6CFB8F9C437C1CB6A08273D65C0C50 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = FBSnapshotTestCase;
+			target = 98A98149697C80CEF8D5772791E92E66 /* FBSnapshotTestCase */;
+			targetProxy = 33A4F7182E49B8901354F2654389DBD4 /* PBXContainerItemProxy */;
+		};
+		3DCA494A0201E7352F5105A7999331AE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = FBSnapshotTestCase;
+			target = 98A98149697C80CEF8D5772791E92E66 /* FBSnapshotTestCase */;
+			targetProxy = A260D3270D096D6DA905AA3AC3748F18 /* PBXContainerItemProxy */;
+		};
+		4F3DB01935D7FCF753E1136895662307 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Specta;
+			target = F8676010755CF1530FC02DA9A0D8822B /* Specta */;
+			targetProxy = 7A4C36E5435C17F10581A3133FAB8247 /* PBXContainerItemProxy */;
+		};
+		5144768AF7004E8280981481B722969E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Analytics;
+			target = 8F50A15C556FFEAD343B69C7EA54092F /* Analytics */;
+			targetProxy = 431C16FD96521BED2A7A92D664B63A01 /* PBXContainerItemProxy */;
+		};
+		D0E4D6F4E56B1D470F6BB56EC744ADE4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Expecta+Snapshots";
+			target = 8B98F09738742E4D780D1B20B468CD95 /* Expecta+Snapshots */;
+			targetProxy = 463F9C49F2789DBE7109DF348220B48A /* PBXContainerItemProxy */;
+		};
+		E3E606868D57932AB079DE3CBAF1989A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Expecta;
+			target = DC371B7477C88184274EC6710690F97C /* Expecta */;
+			targetProxy = A1C7779D9AFA026418507BFB762851E9 /* PBXContainerItemProxy */;
+		};
+		E44667C4D530AB232128F7AE1C11AC4B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = OCMock;
+			target = C260B5A26D3CD54F215E5E39371483B6 /* OCMock */;
+			targetProxy = 324C53BB8D0D250C965FC16D718D7F5A /* PBXContainerItemProxy */;
+		};
+		E7ABC07C9556ABD15016A49A2594013B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Specta;
+			target = F8676010755CF1530FC02DA9A0D8822B /* Specta */;
+			targetProxy = 59A1C12C5FE08F979B0DFAEFC26C59C2 /* PBXContainerItemProxy */;
+		};
+		EFEA5604F40548F9F62BAE9224C6920F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = AvoInspector;
+			target = 5CB07DC335904D6A8475653674C0BF14 /* AvoInspector */;
+			targetProxy = BA40114A2E6A04FF15C5DC99242D4977 /* PBXContainerItemProxy */;
+		};
+		F9249E9E08150332DEE1B5658DE1B8E9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Expecta;
+			target = DC371B7477C88184274EC6710690F97C /* Expecta */;
+			targetProxy = 690624458642502682B8AF217334AE3A /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		024FB92F9580CA1458C46626415DA28F /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = B3E14AD7CC18650F5828D44912CE1285 /* Specta.debug.xcconfig */;
-			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = NO;
-				ENABLE_USER_SCRIPT_SANDBOXING = NO;
-				GCC_PREFIX_HEADER = "Target Support Files/Specta/Specta-prefix.pch";
-				GENERATE_INFOPLIST_FILE = NO;
-				INFOPLIST_FILE = "Target Support Files/Specta/Specta-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Specta/Specta.modulemap";
-				PRODUCT_MODULE_NAME = Specta;
-				PRODUCT_NAME = Specta;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_INSTALL_OBJC_HEADER = YES;
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
 		03D1B00BC903A412FDEE3ABC3A2A2C3C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 47F1A97288EAB253DF092EAC557B66A4 /* Expecta+Snapshots.debug.xcconfig */;
@@ -2378,9 +2351,9 @@
 			};
 			name = Debug;
 		};
-		15EBC4E8116C89E04BC6A09C0BA1D974 /* Release */ = {
+		26F500963E11DCA9C7802BFACF768F43 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A079A922F76B0C044035931B3F95F8B5 /* Specta.release.xcconfig */;
+			baseConfigurationReference = F2AB6AE5A003B408B66B6DF5FEF62423 /* FBSnapshotTestCase.debug.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2393,26 +2366,25 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_MODULE_VERIFIER = NO;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
-				GCC_PREFIX_HEADER = "Target Support Files/Specta/Specta-prefix.pch";
+				GCC_PREFIX_HEADER = "Target Support Files/FBSnapshotTestCase/FBSnapshotTestCase-prefix.pch";
 				GENERATE_INFOPLIST_FILE = NO;
-				INFOPLIST_FILE = "Target Support Files/Specta/Specta-Info.plist";
+				INFOPLIST_FILE = "Target Support Files/FBSnapshotTestCase/FBSnapshotTestCase-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Specta/Specta.modulemap";
-				PRODUCT_MODULE_NAME = Specta;
-				PRODUCT_NAME = Specta;
+				MODULEMAP_FILE = "Target Support Files/FBSnapshotTestCase/FBSnapshotTestCase.modulemap";
+				PRODUCT_MODULE_NAME = FBSnapshotTestCase;
+				PRODUCT_NAME = FBSnapshotTestCase;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
 				SWIFT_INSTALL_OBJC_HEADER = YES;
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
-			name = Release;
+			name = Debug;
 		};
 		2B9E26EAE2CD392AD762421F663075A1 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -2480,6 +2452,42 @@
 			};
 			name = Debug;
 		};
+		2E95F54EF0946902D56E844099127FDF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FD323F46B9B5AE0A51E0DA88761CC07D /* AvoInspector.debug.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = NO;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_PREFIX_HEADER = "Target Support Files/AvoInspector/AvoInspector-prefix.pch";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = "Target Support Files/AvoInspector/AvoInspector-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/AvoInspector/AvoInspector.modulemap";
+				PRODUCT_MODULE_NAME = AvoInspector;
+				PRODUCT_NAME = AvoInspector;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_INSTALL_OBJC_HEADER = YES;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
 		4A5C097B7B36FAAB38245FF3D539CDF6 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3FB83F41F79B40C2D70BE91DA9C38825 /* OCMock.release.xcconfig */;
@@ -2504,6 +2512,42 @@
 				MODULEMAP_FILE = "Target Support Files/OCMock/OCMock.modulemap";
 				PRODUCT_MODULE_NAME = OCMock;
 				PRODUCT_NAME = OCMock;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_INSTALL_OBJC_HEADER = YES;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		4DB27620F63E6B285BE962B196CC26AA /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A283247A6F3CF81322E266BA8819BE3B /* FBSnapshotTestCase.release.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = NO;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_PREFIX_HEADER = "Target Support Files/FBSnapshotTestCase/FBSnapshotTestCase-prefix.pch";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = "Target Support Files/FBSnapshotTestCase/FBSnapshotTestCase-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/FBSnapshotTestCase/FBSnapshotTestCase.modulemap";
+				PRODUCT_MODULE_NAME = FBSnapshotTestCase;
+				PRODUCT_NAME = FBSnapshotTestCase;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
@@ -2551,42 +2595,6 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
-		};
-		58C6B3C649425BB18628D569451474D4 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 99C83184B0AF5E532B2101A5C36DFAAD /* AvoInspector.debug.xcconfig */;
-			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = NO;
-				ENABLE_USER_SCRIPT_SANDBOXING = NO;
-				GCC_PREFIX_HEADER = "Target Support Files/AvoInspector/AvoInspector-prefix.pch";
-				GENERATE_INFOPLIST_FILE = NO;
-				INFOPLIST_FILE = "Target Support Files/AvoInspector/AvoInspector-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/AvoInspector/AvoInspector.modulemap";
-				PRODUCT_MODULE_NAME = AvoInspector;
-				PRODUCT_NAME = AvoInspector;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_INSTALL_OBJC_HEADER = YES;
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
 		};
 		63FAF33E1C55B71A5F5A8B3CC8749F99 /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -2650,9 +2658,46 @@
 			};
 			name = Release;
 		};
-		83BFB0CB05A8E4F7DA13569A80324C1E /* Debug */ = {
+		653A3AB02DF893C5FB9768A9DA9E0B83 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F2AB6AE5A003B408B66B6DF5FEF62423 /* FBSnapshotTestCase.debug.xcconfig */;
+			baseConfigurationReference = 97703A195D2DE48F1EAAE3817B59AA8E /* AvoInspector.release.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = NO;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_PREFIX_HEADER = "Target Support Files/AvoInspector/AvoInspector-prefix.pch";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = "Target Support Files/AvoInspector/AvoInspector-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/AvoInspector/AvoInspector.modulemap";
+				PRODUCT_MODULE_NAME = AvoInspector;
+				PRODUCT_NAME = AvoInspector;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_INSTALL_OBJC_HEADER = YES;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		96FC9EF242BF9BD207AB5E8BD85BF923 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = B3E14AD7CC18650F5828D44912CE1285 /* Specta.debug.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2665,15 +2710,15 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_MODULE_VERIFIER = NO;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
-				GCC_PREFIX_HEADER = "Target Support Files/FBSnapshotTestCase/FBSnapshotTestCase-prefix.pch";
+				GCC_PREFIX_HEADER = "Target Support Files/Specta/Specta-prefix.pch";
 				GENERATE_INFOPLIST_FILE = NO;
-				INFOPLIST_FILE = "Target Support Files/FBSnapshotTestCase/FBSnapshotTestCase-Info.plist";
+				INFOPLIST_FILE = "Target Support Files/Specta/Specta-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/FBSnapshotTestCase/FBSnapshotTestCase.modulemap";
-				PRODUCT_MODULE_NAME = FBSnapshotTestCase;
-				PRODUCT_NAME = FBSnapshotTestCase;
+				MODULEMAP_FILE = "Target Support Files/Specta/Specta.modulemap";
+				PRODUCT_MODULE_NAME = Specta;
+				PRODUCT_NAME = Specta;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
@@ -2756,9 +2801,26 @@
 			};
 			name = Debug;
 		};
-		BAAE637FA5466E035C02BE63979F27FA /* Release */ = {
+		A32EF1B72D0372B8F1C12D0426456C79 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A283247A6F3CF81322E266BA8819BE3B /* FBSnapshotTestCase.release.xcconfig */;
+			baseConfigurationReference = FD323F46B9B5AE0A51E0DA88761CC07D /* AvoInspector.debug.xcconfig */;
+			buildSettings = {
+				CODE_SIGNING_ALLOWED = NO;
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/AvoInspector";
+				IBSC_MODULE = AvoInspector;
+				INFOPLIST_FILE = "Target Support Files/AvoInspector/ResourceBundle-AvoInspector-AvoInspector-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				PRODUCT_NAME = AvoInspector;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Debug;
+		};
+		AE2A324D41ED4ACC321913D8FFFE4B76 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A079A922F76B0C044035931B3F95F8B5 /* Specta.release.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2771,15 +2833,15 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_MODULE_VERIFIER = NO;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
-				GCC_PREFIX_HEADER = "Target Support Files/FBSnapshotTestCase/FBSnapshotTestCase-prefix.pch";
+				GCC_PREFIX_HEADER = "Target Support Files/Specta/Specta-prefix.pch";
 				GENERATE_INFOPLIST_FILE = NO;
-				INFOPLIST_FILE = "Target Support Files/FBSnapshotTestCase/FBSnapshotTestCase-Info.plist";
+				INFOPLIST_FILE = "Target Support Files/Specta/Specta-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/FBSnapshotTestCase/FBSnapshotTestCase.modulemap";
-				PRODUCT_MODULE_NAME = FBSnapshotTestCase;
-				PRODUCT_NAME = FBSnapshotTestCase;
+				MODULEMAP_FILE = "Target Support Files/Specta/Specta.modulemap";
+				PRODUCT_MODULE_NAME = Specta;
+				PRODUCT_NAME = Specta;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
@@ -2789,23 +2851,6 @@
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		C30A29C549FD2391A1A73BFB3BB05820 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3741DA3456746B34C0C805196EEB5725 /* AvoInspector.release.xcconfig */;
-			buildSettings = {
-				CODE_SIGNING_ALLOWED = NO;
-				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/AvoInspector";
-				IBSC_MODULE = AvoInspector;
-				INFOPLIST_FILE = "Target Support Files/AvoInspector/ResourceBundle-AvoInspector-AvoInspector-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				PRODUCT_NAME = AvoInspector;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				WRAPPER_EXTENSION = bundle;
 			};
 			name = Release;
 		};
@@ -2917,43 +2962,6 @@
 			};
 			name = Release;
 		};
-		CB4C588293E4AC0E48B7C84E50A4CA74 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3741DA3456746B34C0C805196EEB5725 /* AvoInspector.release.xcconfig */;
-			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = NO;
-				ENABLE_USER_SCRIPT_SANDBOXING = NO;
-				GCC_PREFIX_HEADER = "Target Support Files/AvoInspector/AvoInspector-prefix.pch";
-				GENERATE_INFOPLIST_FILE = NO;
-				INFOPLIST_FILE = "Target Support Files/AvoInspector/AvoInspector-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/AvoInspector/AvoInspector.modulemap";
-				PRODUCT_MODULE_NAME = AvoInspector;
-				PRODUCT_NAME = AvoInspector;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_INSTALL_OBJC_HEADER = YES;
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
 		D14124E3E09E546C85F095D01988FC0F /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 8CD4B06499A796E38AA33C7995800BB2 /* Analytics.release.xcconfig */;
@@ -3022,23 +3030,6 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		DA0A09F16911F233EB6C243F1BE9DAD7 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 99C83184B0AF5E532B2101A5C36DFAAD /* AvoInspector.debug.xcconfig */;
-			buildSettings = {
-				CODE_SIGNING_ALLOWED = NO;
-				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/AvoInspector";
-				IBSC_MODULE = AvoInspector;
-				INFOPLIST_FILE = "Target Support Files/AvoInspector/ResourceBundle-AvoInspector-AvoInspector-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				PRODUCT_NAME = AvoInspector;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				WRAPPER_EXTENSION = bundle;
 			};
 			name = Debug;
 		};
@@ -3115,6 +3106,23 @@
 			};
 			name = Debug;
 		};
+		F5D947BEE3D9423D23F477BEC63355D6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 97703A195D2DE48F1EAAE3817B59AA8E /* AvoInspector.release.xcconfig */;
+			buildSettings = {
+				CODE_SIGNING_ALLOWED = NO;
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/AvoInspector";
+				IBSC_MODULE = AvoInspector;
+				INFOPLIST_FILE = "Target Support Files/AvoInspector/ResourceBundle-AvoInspector-AvoInspector-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				PRODUCT_NAME = AvoInspector;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -3123,15 +3131,6 @@
 			buildConfigurations = (
 				03D1B00BC903A412FDEE3ABC3A2A2C3C /* Debug */,
 				55419B5327B27F399EBA5EDCF6A4A90F /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		1E24822850917E0A4CA99EA0DC08A2FC /* Build configuration list for PBXNativeTarget "FBSnapshotTestCase" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				83BFB0CB05A8E4F7DA13569A80324C1E /* Debug */,
-				BAAE637FA5466E035C02BE63979F27FA /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -3172,6 +3171,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		4AFA804C77CBCEB6F634A1614BC2E227 /* Build configuration list for PBXNativeTarget "Specta" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				96FC9EF242BF9BD207AB5E8BD85BF923 /* Debug */,
+				AE2A324D41ED4ACC321913D8FFFE4B76 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		58D36124628D73201F2B706F56F5E5CA /* Build configuration list for PBXNativeTarget "Pods-AvoStateOfTracking_Example" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -3181,20 +3189,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		8FB5C638F93C0F43B147FD7E47446807 /* Build configuration list for PBXNativeTarget "AvoInspector-AvoInspector" */ = {
+		86DCBDD365BC533ADFCE308B9FCD5250 /* Build configuration list for PBXNativeTarget "AvoInspector" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				DA0A09F16911F233EB6C243F1BE9DAD7 /* Debug */,
-				C30A29C549FD2391A1A73BFB3BB05820 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		D2261DF368ABC18459ED32B32E944829 /* Build configuration list for PBXNativeTarget "AvoInspector" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				58C6B3C649425BB18628D569451474D4 /* Debug */,
-				CB4C588293E4AC0E48B7C84E50A4CA74 /* Release */,
+				2E95F54EF0946902D56E844099127FDF /* Debug */,
+				653A3AB02DF893C5FB9768A9DA9E0B83 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -3208,11 +3207,20 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		E57921E81D6CA7C1B80D1725EE58663D /* Build configuration list for PBXNativeTarget "Specta" */ = {
+		DAAB846307E594BE918FB931DA2F392E /* Build configuration list for PBXNativeTarget "FBSnapshotTestCase" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				024FB92F9580CA1458C46626415DA28F /* Debug */,
-				15EBC4E8116C89E04BC6A09C0BA1D974 /* Release */,
+				26F500963E11DCA9C7802BFACF768F43 /* Debug */,
+				4DB27620F63E6B285BE962B196CC26AA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E50FCFE0A34CFF32746710256F56DEA2 /* Build configuration list for PBXNativeTarget "AvoInspector-AvoInspector" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A32EF1B72D0372B8F1C12D0426456C79 /* Debug */,
+				F5D947BEE3D9423D23F477BEC63355D6 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Example/Pods/Target Support Files/AvoInspector/AvoInspector-umbrella.h
+++ b/Example/Pods/Target Support Files/AvoInspector/AvoInspector-umbrella.h
@@ -13,6 +13,7 @@
 #import "AvoAnonymousId.h"
 #import "AvoBatcher.h"
 #import "AvoDeduplicator.h"
+#import "AvoEncryption.h"
 #import "AvoEventSpecCache.h"
 #import "AvoEventSpecFetcher.h"
 #import "AvoEventSpecFetchTypes.h"

--- a/Example/Tests/AvoEncryptionIntegrationTests.m
+++ b/Example/Tests/AvoEncryptionIntegrationTests.m
@@ -1,0 +1,383 @@
+//
+//  AvoEncryptionIntegrationTests.m
+//  AvoStateOfTracking_Tests
+//
+//  Integration tests for property value encryption in network handler.
+//
+
+#import <AvoInspector/AvoNetworkCallsHandler.h>
+#import <AvoInspector/AvoEncryption.h>
+#import <AvoInspector/AvoString.h>
+#import <AvoInspector/AvoInt.h>
+#import <AvoInspector/AvoFloat.h>
+#import <AvoInspector/AvoBoolean.h>
+#import <AvoInspector/AvoList.h>
+#import <AvoInspector/AvoObject.h>
+#import <AvoInspector/AvoEventSchemaType.h>
+#import <Security/Security.h>
+
+@interface AvoNetworkCallsHandler ()
+
+@property (readwrite, nonatomic) double samplingRate;
+@property (readwrite, nonatomic) int env;
+@property (readwrite, nonatomic) NSString *endpoint;
+
+@end
+
+@interface AvoEncryptionIntegrationTestHelper : NSObject
++ (SecKeyRef _Nullable)generateTestPrivateKey;
++ (NSString *)publicKeyHexFromPrivateKey:(SecKeyRef)privateKey;
+@end
+
+@implementation AvoEncryptionIntegrationTestHelper
+
++ (SecKeyRef _Nullable)generateTestPrivateKey {
+    NSDictionary *attributes = @{
+        (id)kSecAttrKeyType: (id)kSecAttrKeyTypeECSECPrimeRandom,
+        (id)kSecAttrKeySizeInBits: @256,
+    };
+    CFErrorRef error = NULL;
+    SecKeyRef privateKey = SecKeyCreateRandomKey((__bridge CFDictionaryRef)attributes, &error);
+    if (error != NULL) {
+        CFRelease(error);
+        return NULL;
+    }
+    return privateKey;
+}
+
++ (NSString *)publicKeyHexFromPrivateKey:(SecKeyRef)privateKey {
+    SecKeyRef publicKey = SecKeyCopyPublicKey(privateKey);
+    CFErrorRef error = NULL;
+    CFDataRef pubKeyData = SecKeyCopyExternalRepresentation(publicKey, &error);
+    CFRelease(publicKey);
+
+    NSData *data = (__bridge_transfer NSData *)pubKeyData;
+    NSMutableString *hex = [NSMutableString stringWithCapacity:data.length * 2];
+    const uint8_t *bytes = data.bytes;
+    for (NSUInteger i = 0; i < data.length; i++) {
+        [hex appendFormat:@"%02x", bytes[i]];
+    }
+    return hex;
+}
+
+@end
+
+SpecBegin(AvoEncryptionIntegration)
+
+describe(@"Encryption Integration", ^{
+
+    __block SecKeyRef testPrivateKey;
+    __block NSString *testPublicKeyHex;
+
+    beforeAll(^{
+        testPrivateKey = [AvoEncryptionIntegrationTestHelper generateTestPrivateKey];
+        expect(testPrivateKey).toNot.beNil();
+        testPublicKeyHex = [AvoEncryptionIntegrationTestHelper publicKeyHexFromPrivateKey:testPrivateKey];
+        expect(testPublicKeyHex).toNot.beNil();
+    });
+
+    afterAll(^{
+        if (testPrivateKey) CFRelease(testPrivateKey);
+    });
+
+    // =========================================================================
+    // Batched event encryption tests
+    // =========================================================================
+
+    describe(@"batched event encryption", ^{
+
+        it(@"includes encrypted values in dev mode", ^{
+            AvoNetworkCallsHandler *handler = [[AvoNetworkCallsHandler alloc]
+                initWithApiKey:@"testApiKey" appName:@"testApp" appVersion:@"1.0.0"
+                libVersion:@"7" env:1 endpoint:@"test" publicEncryptionKey:testPublicKeyHex];
+
+            NSMutableDictionary *schema = [NSMutableDictionary new];
+            [schema setObject:[AvoString new] forKey:@"userId"];
+            [schema setObject:[AvoInt new] forKey:@"count"];
+
+            NSDictionary *eventProperties = @{@"userId": @"user123", @"count": @42};
+
+            NSMutableDictionary *body = [handler bodyForTrackSchemaCall:@"TestEvent"
+                                                                schema:schema
+                                                               eventId:nil
+                                                             eventHash:nil
+                                                       eventProperties:eventProperties];
+
+            NSArray *properties = body[@"eventProperties"];
+            expect(properties).toNot.beNil();
+
+            BOOL foundEncryptedUserId = NO;
+            BOOL foundEncryptedCount = NO;
+            for (NSDictionary *prop in properties) {
+                if ([prop[@"propertyName"] isEqualToString:@"userId"]) {
+                    expect(prop[@"encryptedPropertyValue"]).toNot.beNil();
+                    foundEncryptedUserId = YES;
+                }
+                if ([prop[@"propertyName"] isEqualToString:@"count"]) {
+                    expect(prop[@"encryptedPropertyValue"]).toNot.beNil();
+                    foundEncryptedCount = YES;
+                }
+            }
+            expect(foundEncryptedUserId).to.beTruthy();
+            expect(foundEncryptedCount).to.beTruthy();
+        });
+
+        it(@"includes encrypted values in staging mode", ^{
+            AvoNetworkCallsHandler *handler = [[AvoNetworkCallsHandler alloc]
+                initWithApiKey:@"testApiKey" appName:@"testApp" appVersion:@"1.0.0"
+                libVersion:@"7" env:2 endpoint:@"test" publicEncryptionKey:testPublicKeyHex];
+
+            NSMutableDictionary *schema = [NSMutableDictionary new];
+            [schema setObject:[AvoString new] forKey:@"name"];
+
+            NSDictionary *eventProperties = @{@"name": @"test"};
+
+            NSMutableDictionary *body = [handler bodyForTrackSchemaCall:@"TestEvent"
+                                                                schema:schema
+                                                               eventId:nil
+                                                             eventHash:nil
+                                                       eventProperties:eventProperties];
+
+            NSArray *properties = body[@"eventProperties"];
+            NSDictionary *prop = properties[0];
+            expect(prop[@"encryptedPropertyValue"]).toNot.beNil();
+        });
+
+        it(@"no encryption in prod even with key", ^{
+            AvoNetworkCallsHandler *handler = [[AvoNetworkCallsHandler alloc]
+                initWithApiKey:@"testApiKey" appName:@"testApp" appVersion:@"1.0.0"
+                libVersion:@"7" env:0 endpoint:@"test" publicEncryptionKey:testPublicKeyHex];
+
+            NSMutableDictionary *schema = [NSMutableDictionary new];
+            [schema setObject:[AvoString new] forKey:@"userId"];
+
+            NSDictionary *eventProperties = @{@"userId": @"user123"};
+
+            NSMutableDictionary *body = [handler bodyForTrackSchemaCall:@"TestEvent"
+                                                                schema:schema
+                                                               eventId:nil
+                                                             eventHash:nil
+                                                       eventProperties:eventProperties];
+
+            NSArray *properties = body[@"eventProperties"];
+            for (NSDictionary *prop in properties) {
+                expect(prop[@"encryptedPropertyValue"]).to.beNil();
+            }
+        });
+
+        it(@"no encryption when key is nil", ^{
+            AvoNetworkCallsHandler *handler = [[AvoNetworkCallsHandler alloc]
+                initWithApiKey:@"testApiKey" appName:@"testApp" appVersion:@"1.0.0"
+                libVersion:@"7" env:1 endpoint:@"test" publicEncryptionKey:nil];
+
+            NSMutableDictionary *schema = [NSMutableDictionary new];
+            [schema setObject:[AvoString new] forKey:@"userId"];
+
+            NSDictionary *eventProperties = @{@"userId": @"user123"};
+
+            NSMutableDictionary *body = [handler bodyForTrackSchemaCall:@"TestEvent"
+                                                                schema:schema
+                                                               eventId:nil
+                                                             eventHash:nil
+                                                       eventProperties:eventProperties];
+
+            NSArray *properties = body[@"eventProperties"];
+            for (NSDictionary *prop in properties) {
+                expect(prop[@"encryptedPropertyValue"]).to.beNil();
+            }
+        });
+    });
+
+    // =========================================================================
+    // publicEncryptionKey in base body tests
+    // =========================================================================
+
+    describe(@"publicEncryptionKey in base body", ^{
+
+        it(@"includes publicEncryptionKey when present", ^{
+            AvoNetworkCallsHandler *handler = [[AvoNetworkCallsHandler alloc]
+                initWithApiKey:@"testApiKey" appName:@"testApp" appVersion:@"1.0.0"
+                libVersion:@"7" env:1 endpoint:@"test" publicEncryptionKey:testPublicKeyHex];
+
+            NSMutableDictionary *body = [handler bodyForTrackSchemaCall:@"TestEvent"
+                                                                schema:[NSMutableDictionary new]
+                                                               eventId:nil
+                                                             eventHash:nil
+                                                       eventProperties:nil];
+
+            expect(body[@"publicEncryptionKey"]).to.equal(testPublicKeyHex);
+        });
+
+        it(@"does not include publicEncryptionKey when nil", ^{
+            AvoNetworkCallsHandler *handler = [[AvoNetworkCallsHandler alloc]
+                initWithApiKey:@"testApiKey" appName:@"testApp" appVersion:@"1.0.0"
+                libVersion:@"7" env:1 endpoint:@"test" publicEncryptionKey:nil];
+
+            NSMutableDictionary *body = [handler bodyForTrackSchemaCall:@"TestEvent"
+                                                                schema:[NSMutableDictionary new]
+                                                               eventId:nil
+                                                             eventHash:nil
+                                                       eventProperties:nil];
+
+            expect(body[@"publicEncryptionKey"]).to.beNil();
+        });
+    });
+
+    // =========================================================================
+    // Nested object and list tests
+    // =========================================================================
+
+    describe(@"nested objects and lists", ^{
+
+        it(@"nested object children are encrypted", ^{
+            AvoNetworkCallsHandler *handler = [[AvoNetworkCallsHandler alloc]
+                initWithApiKey:@"testApiKey" appName:@"testApp" appVersion:@"1.0.0"
+                libVersion:@"7" env:1 endpoint:@"test" publicEncryptionKey:testPublicKeyHex];
+
+            AvoObject *addressObj = [AvoObject new];
+            [addressObj.fields setObject:[AvoString new] forKey:@"street"];
+            [addressObj.fields setObject:[AvoInt new] forKey:@"zip"];
+
+            NSMutableDictionary *schema = [NSMutableDictionary new];
+            [schema setObject:addressObj forKey:@"address"];
+
+            NSDictionary *innerProps = @{@"street": @"123 Main St", @"zip": @90210};
+            NSDictionary *eventProperties = @{@"address": innerProps};
+
+            NSMutableDictionary *body = [handler bodyForTrackSchemaCall:@"TestEvent"
+                                                                schema:schema
+                                                               eventId:nil
+                                                             eventHash:nil
+                                                       eventProperties:eventProperties];
+
+            NSArray *properties = body[@"eventProperties"];
+            NSDictionary *addressProp = nil;
+            for (NSDictionary *p in properties) {
+                if ([p[@"propertyName"] isEqualToString:@"address"]) {
+                    addressProp = p;
+                    break;
+                }
+            }
+            expect(addressProp).toNot.beNil();
+            expect(addressProp[@"encryptedPropertyValue"]).to.beNil();
+
+            NSArray *children = addressProp[@"children"];
+            expect(children).toNot.beNil();
+
+            BOOL foundEncryptedStreet = NO;
+            BOOL foundEncryptedZip = NO;
+            for (NSDictionary *child in children) {
+                if ([child[@"propertyName"] isEqualToString:@"street"]) {
+                    expect(child[@"encryptedPropertyValue"]).toNot.beNil();
+                    foundEncryptedStreet = YES;
+                }
+                if ([child[@"propertyName"] isEqualToString:@"zip"]) {
+                    expect(child[@"encryptedPropertyValue"]).toNot.beNil();
+                    foundEncryptedZip = YES;
+                }
+            }
+            expect(foundEncryptedStreet).to.beTruthy();
+            expect(foundEncryptedZip).to.beTruthy();
+        });
+
+        it(@"list values are NOT encrypted", ^{
+            AvoNetworkCallsHandler *handler = [[AvoNetworkCallsHandler alloc]
+                initWithApiKey:@"testApiKey" appName:@"testApp" appVersion:@"1.0.0"
+                libVersion:@"7" env:1 endpoint:@"test" publicEncryptionKey:testPublicKeyHex];
+
+            AvoList *list = [AvoList new];
+            list.subtypes = [[NSMutableSet alloc] initWithArray:@[[AvoString new]]];
+
+            NSMutableDictionary *schema = [NSMutableDictionary new];
+            [schema setObject:list forKey:@"tags"];
+
+            NSDictionary *eventProperties = @{@"tags": @[@"a", @"b", @"c"]};
+
+            NSMutableDictionary *body = [handler bodyForTrackSchemaCall:@"TestEvent"
+                                                                schema:schema
+                                                               eventId:nil
+                                                             eventHash:nil
+                                                       eventProperties:eventProperties];
+
+            NSArray *properties = body[@"eventProperties"];
+            for (NSDictionary *prop in properties) {
+                if ([prop[@"propertyName"] isEqualToString:@"tags"]) {
+                    expect(prop[@"encryptedPropertyValue"]).to.beNil();
+                }
+            }
+        });
+    });
+
+    // =========================================================================
+    // shouldEncrypt tests
+    // =========================================================================
+
+    describe(@"shouldEncrypt", ^{
+
+        it(@"returns YES for dev with key", ^{
+            AvoNetworkCallsHandler *handler = [[AvoNetworkCallsHandler alloc]
+                initWithApiKey:@"key" appName:@"app" appVersion:@"1.0"
+                libVersion:@"7" env:1 endpoint:@"test" publicEncryptionKey:testPublicKeyHex];
+            expect([handler shouldEncrypt]).to.beTruthy();
+        });
+
+        it(@"returns YES for staging with key", ^{
+            AvoNetworkCallsHandler *handler = [[AvoNetworkCallsHandler alloc]
+                initWithApiKey:@"key" appName:@"app" appVersion:@"1.0"
+                libVersion:@"7" env:2 endpoint:@"test" publicEncryptionKey:testPublicKeyHex];
+            expect([handler shouldEncrypt]).to.beTruthy();
+        });
+
+        it(@"returns NO for prod", ^{
+            AvoNetworkCallsHandler *handler = [[AvoNetworkCallsHandler alloc]
+                initWithApiKey:@"key" appName:@"app" appVersion:@"1.0"
+                libVersion:@"7" env:0 endpoint:@"test" publicEncryptionKey:testPublicKeyHex];
+            expect([handler shouldEncrypt]).to.beFalsy();
+        });
+
+        it(@"returns NO for nil key", ^{
+            AvoNetworkCallsHandler *handler = [[AvoNetworkCallsHandler alloc]
+                initWithApiKey:@"key" appName:@"app" appVersion:@"1.0"
+                libVersion:@"7" env:1 endpoint:@"test" publicEncryptionKey:nil];
+            expect([handler shouldEncrypt]).to.beFalsy();
+        });
+
+        it(@"returns NO for empty key", ^{
+            AvoNetworkCallsHandler *handler = [[AvoNetworkCallsHandler alloc]
+                initWithApiKey:@"key" appName:@"app" appVersion:@"1.0"
+                libVersion:@"7" env:1 endpoint:@"test" publicEncryptionKey:@""];
+            expect([handler shouldEncrypt]).to.beFalsy();
+        });
+    });
+
+    // =========================================================================
+    // JSON stringify value tests
+    // =========================================================================
+
+    describe(@"jsonStringifyValue", ^{
+
+        it(@"stringifies a string", ^{
+            expect([AvoNetworkCallsHandler jsonStringifyValue:@"hello"]).to.equal(@"\"hello\"");
+        });
+
+        it(@"stringifies an integer", ^{
+            expect([AvoNetworkCallsHandler jsonStringifyValue:@42]).to.equal(@"42");
+        });
+
+        it(@"stringifies a double", ^{
+            NSString *result = [AvoNetworkCallsHandler jsonStringifyValue:@3.14];
+            // NSJSONSerialization may produce "3.14" or "3.1400000000000001" depending on precision
+            expect([result hasPrefix:@"3.14"]).to.beTruthy();
+        });
+
+        it(@"stringifies a boolean true", ^{
+            expect([AvoNetworkCallsHandler jsonStringifyValue:@YES]).to.equal(@"true");
+        });
+
+        it(@"stringifies a boolean false", ^{
+            expect([AvoNetworkCallsHandler jsonStringifyValue:@NO]).to.equal(@"false");
+        });
+    });
+});
+
+SpecEnd

--- a/Example/Tests/AvoEncryptionTests.m
+++ b/Example/Tests/AvoEncryptionTests.m
@@ -1,0 +1,281 @@
+//
+//  AvoEncryptionTests.m
+//  AvoStateOfTracking_Tests
+//
+//  Tests for AvoEncryption ECIES (P-256 + AES-256-GCM).
+//
+
+#import <AvoInspector/AvoEncryption.h>
+#import <Security/Security.h>
+#import <CommonCrypto/CommonCrypto.h>
+#import <CommonCrypto/CommonCryptor.h>
+
+// Forward-declare GCM functions
+extern CCCryptorStatus CCCryptorGCMSetIV(CCCryptorRef cryptorRef, const void *iv, size_t ivLen);
+extern CCCryptorStatus CCCryptorGCMDecrypt(CCCryptorRef cryptorRef, const void *dataIn, size_t dataInLength, void *dataOut);
+extern CCCryptorStatus CCCryptorGCMFinalize(CCCryptorRef cryptorRef, void *tagOut, size_t tagLength);
+
+@interface AvoEncryptionTestHelper : NSObject
++ (SecKeyRef _Nullable)generateTestPrivateKey;
++ (NSString *)publicKeyHexFromPrivateKey:(SecKeyRef)privateKey;
++ (NSString * _Nullable)decrypt:(NSString *)base64Encrypted privateKey:(SecKeyRef)privateKey;
+@end
+
+@implementation AvoEncryptionTestHelper
+
++ (SecKeyRef _Nullable)generateTestPrivateKey {
+    NSDictionary *attributes = @{
+        (id)kSecAttrKeyType: (id)kSecAttrKeyTypeECSECPrimeRandom,
+        (id)kSecAttrKeySizeInBits: @256,
+    };
+    CFErrorRef error = NULL;
+    SecKeyRef privateKey = SecKeyCreateRandomKey((__bridge CFDictionaryRef)attributes, &error);
+    if (error != NULL) {
+        CFRelease(error);
+        return NULL;
+    }
+    return privateKey;
+}
+
++ (NSString *)publicKeyHexFromPrivateKey:(SecKeyRef)privateKey {
+    SecKeyRef publicKey = SecKeyCopyPublicKey(privateKey);
+    CFErrorRef error = NULL;
+    CFDataRef pubKeyData = SecKeyCopyExternalRepresentation(publicKey, &error);
+    CFRelease(publicKey);
+
+    NSData *data = (__bridge_transfer NSData *)pubKeyData;
+    NSMutableString *hex = [NSMutableString stringWithCapacity:data.length * 2];
+    const uint8_t *bytes = data.bytes;
+    for (NSUInteger i = 0; i < data.length; i++) {
+        [hex appendFormat:@"%02x", bytes[i]];
+    }
+    return hex;
+}
+
++ (NSString * _Nullable)decrypt:(NSString *)base64Encrypted privateKey:(SecKeyRef)privateKey {
+    NSData *data = [[NSData alloc] initWithBase64EncodedString:base64Encrypted options:0];
+    if (data == nil || data.length < 98) return nil;
+
+    const uint8_t *bytes = data.bytes;
+
+    // Version byte
+    if (bytes[0] != 0x00) return nil;
+
+    // Parse ephemeral public key (65 bytes)
+    NSData *ephemeralPubData = [data subdataWithRange:NSMakeRange(1, 65)];
+    // IV (16 bytes)
+    NSData *iv = [data subdataWithRange:NSMakeRange(66, 16)];
+    // Auth tag (16 bytes)
+    NSData *authTag = [data subdataWithRange:NSMakeRange(82, 16)];
+    // Ciphertext (rest)
+    NSUInteger ciphertextLen = data.length - 98;
+    NSData *ciphertext = [data subdataWithRange:NSMakeRange(98, ciphertextLen)];
+
+    // Reconstruct ephemeral public key
+    NSDictionary *keyAttrs = @{
+        (id)kSecAttrKeyType: (id)kSecAttrKeyTypeECSECPrimeRandom,
+        (id)kSecAttrKeyClass: (id)kSecAttrKeyClassPublic,
+        (id)kSecAttrKeySizeInBits: @256,
+    };
+    CFErrorRef error = NULL;
+    SecKeyRef ephemeralPubKey = SecKeyCreateWithData((__bridge CFDataRef)ephemeralPubData,
+                                                      (__bridge CFDictionaryRef)keyAttrs,
+                                                      &error);
+    if (ephemeralPubKey == NULL) {
+        if (error) CFRelease(error);
+        return nil;
+    }
+
+    // ECDH shared secret
+    NSDictionary *params = @{};
+    CFDataRef sharedSecretRef = SecKeyCopyKeyExchangeResult(privateKey,
+                                                             kSecKeyAlgorithmECDHKeyExchangeStandard,
+                                                             ephemeralPubKey,
+                                                             (__bridge CFDictionaryRef)params,
+                                                             &error);
+    CFRelease(ephemeralPubKey);
+    if (sharedSecretRef == NULL) {
+        if (error) CFRelease(error);
+        return nil;
+    }
+    NSData *sharedSecret = (__bridge_transfer NSData *)sharedSecretRef;
+
+    // KDF: SHA-256
+    uint8_t aesKeyBytes[CC_SHA256_DIGEST_LENGTH];
+    CC_SHA256(sharedSecret.bytes, (CC_LONG)sharedSecret.length, aesKeyBytes);
+
+    // AES-256-GCM decrypt
+    // Concatenate ciphertext + authTag (GCM tag appended) and use SecKeyCreateDecryptedData pattern
+    // Or use CCCryptorGCM step API with tag verification
+    NSMutableData *plaintext = [NSMutableData dataWithLength:ciphertextLen];
+
+    CCCryptorRef cryptorRef = NULL;
+    CCCryptorStatus status = CCCryptorCreateWithMode(kCCDecrypt,
+                                                      11, // kCCModeGCM
+                                                      kCCAlgorithmAES,
+                                                      ccNoPadding,
+                                                      NULL,
+                                                      aesKeyBytes,
+                                                      CC_SHA256_DIGEST_LENGTH,
+                                                      NULL, 0, 0, 0,
+                                                      &cryptorRef);
+    if (status != kCCSuccess || cryptorRef == NULL) return nil;
+
+    status = CCCryptorGCMSetIV(cryptorRef, iv.bytes, iv.length);
+    if (status != kCCSuccess) { CCCryptorRelease(cryptorRef); return nil; }
+
+    status = CCCryptorGCMDecrypt(cryptorRef, ciphertext.bytes, ciphertext.length, plaintext.mutableBytes);
+    if (status != kCCSuccess) { CCCryptorRelease(cryptorRef); return nil; }
+
+    // For GCM finalize/tag verification: pass the expected tag to CCCryptorGCMFinalize
+    // On iOS, CCCryptorGCMFinalize in decrypt mode expects the tag to verify against
+    NSMutableData *tagCopy = [NSMutableData dataWithData:authTag];
+    status = CCCryptorGCMFinalize(cryptorRef, tagCopy.mutableBytes, tagCopy.length);
+    CCCryptorRelease(cryptorRef);
+
+    // On some CommonCrypto versions, finalize in decrypt mode returns kCCUnimplemented
+    // if tag verification isn't supported inline. In that case, we skip tag verification
+    // since the integration tests confirm encryption correctness.
+    if (status != kCCSuccess && status != -4 /* kCCUnimplemented */) return nil;
+
+    return [[NSString alloc] initWithData:plaintext encoding:NSUTF8StringEncoding];
+}
+
+@end
+
+SpecBegin(AvoEncryption)
+
+describe(@"AvoEncryption", ^{
+
+    __block SecKeyRef testPrivateKey;
+    __block NSString *testPublicKeyHex;
+
+    beforeAll(^{
+        testPrivateKey = [AvoEncryptionTestHelper generateTestPrivateKey];
+        expect(testPrivateKey).toNot.beNil();
+        testPublicKeyHex = [AvoEncryptionTestHelper publicKeyHexFromPrivateKey:testPrivateKey];
+        expect(testPublicKeyHex).toNot.beNil();
+    });
+
+    afterAll(^{
+        if (testPrivateKey) CFRelease(testPrivateKey);
+    });
+
+    it(@"encrypts and decrypts a string value", ^{
+        NSString *plaintext = @"\"hello world\"";
+        NSString *encrypted = [AvoEncryption encrypt:plaintext recipientPublicKeyHex:testPublicKeyHex];
+        expect(encrypted).toNot.beNil();
+
+        NSString *decrypted = [AvoEncryptionTestHelper decrypt:encrypted privateKey:testPrivateKey];
+        expect(decrypted).to.equal(plaintext);
+    });
+
+    it(@"encrypts and decrypts an integer value", ^{
+        NSString *plaintext = @"42";
+        NSString *encrypted = [AvoEncryption encrypt:plaintext recipientPublicKeyHex:testPublicKeyHex];
+        expect(encrypted).toNot.beNil();
+
+        NSString *decrypted = [AvoEncryptionTestHelper decrypt:encrypted privateKey:testPrivateKey];
+        expect(decrypted).to.equal(plaintext);
+    });
+
+    it(@"encrypts and decrypts a double value", ^{
+        NSString *plaintext = @"3.14";
+        NSString *encrypted = [AvoEncryption encrypt:plaintext recipientPublicKeyHex:testPublicKeyHex];
+        expect(encrypted).toNot.beNil();
+
+        NSString *decrypted = [AvoEncryptionTestHelper decrypt:encrypted privateKey:testPrivateKey];
+        expect(decrypted).to.equal(plaintext);
+    });
+
+    it(@"encrypts and decrypts a boolean value", ^{
+        NSString *plaintext = @"true";
+        NSString *encrypted = [AvoEncryption encrypt:plaintext recipientPublicKeyHex:testPublicKeyHex];
+        expect(encrypted).toNot.beNil();
+
+        NSString *decrypted = [AvoEncryptionTestHelper decrypt:encrypted privateKey:testPrivateKey];
+        expect(decrypted).to.equal(plaintext);
+    });
+
+    it(@"output format has correct structure", ^{
+        NSString *encrypted = [AvoEncryption encrypt:@"test" recipientPublicKeyHex:testPublicKeyHex];
+        expect(encrypted).toNot.beNil();
+
+        NSData *data = [[NSData alloc] initWithBase64EncodedString:encrypted options:0];
+        expect(data).toNot.beNil();
+
+        // Minimum size: 1 (version) + 65 (pubkey) + 16 (iv) + 16 (tag) + at least 1 byte ciphertext
+        expect(data.length).to.beGreaterThanOrEqualTo(99);
+
+        const uint8_t *bytes = data.bytes;
+        // Version byte
+        expect(bytes[0]).to.equal(0x00);
+        // Ephemeral public key starts with 0x04 (uncompressed)
+        expect(bytes[1]).to.equal(0x04);
+    });
+
+    it(@"different encryptions produce different output", ^{
+        NSString *plaintext = @"\"same text\"";
+        NSString *encrypted1 = [AvoEncryption encrypt:plaintext recipientPublicKeyHex:testPublicKeyHex];
+        NSString *encrypted2 = [AvoEncryption encrypt:plaintext recipientPublicKeyHex:testPublicKeyHex];
+
+        expect(encrypted1).toNot.beNil();
+        expect(encrypted2).toNot.beNil();
+        expect(encrypted1).toNot.equal(encrypted2);
+
+        // Both should decrypt to the same plaintext
+        NSString *decrypted1 = [AvoEncryptionTestHelper decrypt:encrypted1 privateKey:testPrivateKey];
+        NSString *decrypted2 = [AvoEncryptionTestHelper decrypt:encrypted2 privateKey:testPrivateKey];
+        expect(decrypted1).to.equal(plaintext);
+        expect(decrypted2).to.equal(plaintext);
+    });
+
+    it(@"returns nil for nil key", ^{
+        NSString *result = [AvoEncryption encrypt:@"test" recipientPublicKeyHex:nil];
+        expect(result).to.beNil();
+    });
+
+    it(@"returns nil for empty key", ^{
+        NSString *result = [AvoEncryption encrypt:@"test" recipientPublicKeyHex:@""];
+        expect(result).to.beNil();
+    });
+
+    it(@"returns nil for nil plaintext", ^{
+        NSString *result = [AvoEncryption encrypt:nil recipientPublicKeyHex:testPublicKeyHex];
+        expect(result).to.beNil();
+    });
+
+    it(@"returns nil for invalid key", ^{
+        NSString *result = [AvoEncryption encrypt:@"test" recipientPublicKeyHex:@"deadbeef"];
+        expect(result).to.beNil();
+    });
+
+    it(@"encrypts and decrypts with compressed key", ^{
+        // Build compressed key from the test public key
+        SecKeyRef pubKey = SecKeyCopyPublicKey(testPrivateKey);
+        CFErrorRef error = NULL;
+        CFDataRef pubKeyData = SecKeyCopyExternalRepresentation(pubKey, &error);
+        CFRelease(pubKey);
+        NSData *uncompressed = (__bridge_transfer NSData *)pubKeyData;
+
+        // uncompressed is 0x04 + X(32) + Y(32)
+        const uint8_t *ubytes = uncompressed.bytes;
+        uint8_t prefix = (ubytes[64] & 1) ? 0x03 : 0x02;
+
+        NSMutableString *compressedHex = [NSMutableString stringWithCapacity:66];
+        [compressedHex appendFormat:@"%02x", prefix];
+        for (int i = 1; i <= 32; i++) {
+            [compressedHex appendFormat:@"%02x", ubytes[i]];
+        }
+        expect(compressedHex.length).to.equal(66);
+
+        NSString *plaintext = @"\"compressed key test\"";
+        NSString *encrypted = [AvoEncryption encrypt:plaintext recipientPublicKeyHex:compressedHex];
+        expect(encrypted).toNot.beNil();
+
+        NSString *decrypted = [AvoEncryptionTestHelper decrypt:encrypted privateKey:testPrivateKey];
+        expect(decrypted).to.equal(plaintext);
+    });
+});
+
+SpecEnd

--- a/Example/Tests/AvoEncryptionTests.m
+++ b/Example/Tests/AvoEncryptionTests.m
@@ -10,10 +10,16 @@
 #import <CommonCrypto/CommonCrypto.h>
 #import <CommonCrypto/CommonCryptor.h>
 
-// Forward-declare GCM functions
-extern CCCryptorStatus CCCryptorGCMSetIV(CCCryptorRef cryptorRef, const void *iv, size_t ivLen);
-extern CCCryptorStatus CCCryptorGCMDecrypt(CCCryptorRef cryptorRef, const void *dataIn, size_t dataInLength, void *dataOut);
-extern CCCryptorStatus CCCryptorGCMFinalize(CCCryptorRef cryptorRef, void *tagOut, size_t tagLength);
+// AES-GCM oneshot API — stable exported symbol in libcommonCrypto, not in public headers.
+// See AvoEncryption.m header comment for rationale.
+extern CCCryptorStatus CCCryptorGCMOneshotDecrypt(
+    CCAlgorithm alg,
+    const void *key, size_t keyLength,
+    const void *iv, size_t ivLength,
+    const void *aad, size_t aadLength,
+    const void *dataIn, size_t dataInLength,
+    void *dataOut,
+    const void *tag, size_t tagLength);
 
 @interface AvoEncryptionTestHelper : NSObject
 + (SecKeyRef _Nullable)generateTestPrivateKey;
@@ -104,39 +110,18 @@ extern CCCryptorStatus CCCryptorGCMFinalize(CCCryptorRef cryptorRef, void *tagOu
     uint8_t aesKeyBytes[CC_SHA256_DIGEST_LENGTH];
     CC_SHA256(sharedSecret.bytes, (CC_LONG)sharedSecret.length, aesKeyBytes);
 
-    // AES-256-GCM decrypt
-    // Concatenate ciphertext + authTag (GCM tag appended) and use SecKeyCreateDecryptedData pattern
-    // Or use CCCryptorGCM step API with tag verification
+    // AES-256-GCM decrypt using oneshot API
     NSMutableData *plaintext = [NSMutableData dataWithLength:ciphertextLen];
 
-    CCCryptorRef cryptorRef = NULL;
-    CCCryptorStatus status = CCCryptorCreateWithMode(kCCDecrypt,
-                                                      11, // kCCModeGCM
-                                                      kCCAlgorithmAES,
-                                                      ccNoPadding,
-                                                      NULL,
-                                                      aesKeyBytes,
-                                                      CC_SHA256_DIGEST_LENGTH,
-                                                      NULL, 0, 0, 0,
-                                                      &cryptorRef);
-    if (status != kCCSuccess || cryptorRef == NULL) return nil;
-
-    status = CCCryptorGCMSetIV(cryptorRef, iv.bytes, iv.length);
-    if (status != kCCSuccess) { CCCryptorRelease(cryptorRef); return nil; }
-
-    status = CCCryptorGCMDecrypt(cryptorRef, ciphertext.bytes, ciphertext.length, plaintext.mutableBytes);
-    if (status != kCCSuccess) { CCCryptorRelease(cryptorRef); return nil; }
-
-    // For GCM finalize/tag verification: pass the expected tag to CCCryptorGCMFinalize
-    // On iOS, CCCryptorGCMFinalize in decrypt mode expects the tag to verify against
-    NSMutableData *tagCopy = [NSMutableData dataWithData:authTag];
-    status = CCCryptorGCMFinalize(cryptorRef, tagCopy.mutableBytes, tagCopy.length);
-    CCCryptorRelease(cryptorRef);
-
-    // On some CommonCrypto versions, finalize in decrypt mode returns kCCUnimplemented
-    // if tag verification isn't supported inline. In that case, we skip tag verification
-    // since the integration tests confirm encryption correctness.
-    if (status != kCCSuccess && status != -4 /* kCCUnimplemented */) return nil;
+    CCCryptorStatus status = CCCryptorGCMOneshotDecrypt(
+        kCCAlgorithmAES,
+        aesKeyBytes, CC_SHA256_DIGEST_LENGTH,
+        iv.bytes, iv.length,
+        NULL, 0,  // no AAD
+        ciphertext.bytes, ciphertext.length,
+        plaintext.mutableBytes,
+        authTag.bytes, authTag.length);
+    if (status != kCCSuccess) return nil;
 
     return [[NSString alloc] initWithData:plaintext encoding:NSUTF8StringEncoding];
 }
@@ -248,6 +233,25 @@ describe(@"AvoEncryption", ^{
     it(@"returns nil for invalid key", ^{
         NSString *result = [AvoEncryption encrypt:@"test" recipientPublicKeyHex:@"deadbeef"];
         expect(result).to.beNil();
+    });
+
+    it(@"decompresses known secp256r1 test vector correctly", ^{
+        // secp256r1 generator point G (a known point on the curve)
+        // X = 6B17D1F2E12C4247F8BCE6E563A440F277037D812DEB33A0F4A13945D898C296
+        // Y = 4FE342E2FE1A7F9B8EE7EB4A7C0F9E162BCE33576B315ECECBB6406837BF51F5
+        // Y is odd (last byte 0xF5, bit 0 = 1) → compressed prefix 0x03
+        NSString *compressedHex = @"036B17D1F2E12C4247F8BCE6E563A440F277037D812DEB33A0F4A13945D898C296";
+
+        // Encrypt with the compressed generator point. If decompression is wrong,
+        // SecKeyCreateWithData will reject the reconstructed uncompressed key → nil.
+        NSString *encrypted = [AvoEncryption encrypt:@"test" recipientPublicKeyHex:compressedHex];
+        expect(encrypted).toNot.beNil();
+
+        // Verify the ephemeral key in the output uses the correct uncompressed format
+        NSData *data = [[NSData alloc] initWithBase64EncodedString:encrypted options:0];
+        const uint8_t *bytes = data.bytes;
+        expect(bytes[0]).to.equal(0x00); // version
+        expect(bytes[1]).to.equal(0x04); // uncompressed ephemeral key
     });
 
     it(@"encrypts and decrypts with compressed key", ^{


### PR DESCRIPTION
## What changed?

- **AvoEncryption.h/.m** — Standalone ECIES encryption class (P-256 + AES-256-GCM) with support for both compressed and uncompressed EC public keys
- **AvoNetworkCallsHandler** — Added `publicEncryptionKey` to init, `shouldEncrypt` gating (dev/staging only), `addEncryptedValues` recursive walker that encrypts primitive property values (skips lists, recurses objects), `jsonStringifyValue` helper, and `publicEncryptionKey` in base request body
- **AvoBatcher** — Threaded `eventProperties` parameter through `handleTrackSchema:` to enable encryption in the batched path
- **AvoInspector** — New init methods accepting `publicEncryptionKey` (backwards compatible), threaded `eventProperties` through all code paths (batched + validated)
- **Tests** — 29 new tests: 11 unit tests (round-trip encrypt/decrypt, format validation, compressed key support, edge cases) and 18 integration tests (encryption in dev/staging, no encryption in prod, nested objects, lists skipped, shouldEncrypt logic, jsonStringifyValue)
- **LocalConfig.h** — Gitignored local API key override mechanism with `__has_include` fallback

Mirrors [android-avo-inspector PR #38](https://github.com/avohq/android-avo-inspector/pull/38).

## How to test this PR:

- [ ] Run the test suite: `xcodebuild test` — all 153 tests pass (including 29 new encryption tests)
- [ ] Init `AvoInspector` with a P-256 public key in dev mode, track an event with properties, and verify `encryptedPropertyValue` appears in the network request body
- [ ] Verify no encryption occurs in prod mode even with a key provided
- [ ] Verify existing init methods without `publicEncryptionKey` still work (backwards compatible)

## Before merging
- [x] Security impact of change has been considered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for encrypting property values using public encryption keys during initialization
  * Extended event tracking to accept and transmit event properties alongside schema data
  * Added new initialization options to configure public encryption keys and custom endpoints

* **Chores**
  * Updated configuration system to support local environment overrides

<!-- end of auto-generated comment: release notes by coderabbit.ai -->