### PR TITLE
chore: bump version to 2.2.0

### DIFF
--- a/AvoInspector.podspec
+++ b/AvoInspector.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'AvoInspector'
-  s.version          = '2.1.0'
+  s.version          = '2.2.0'
   s.summary          = 'Avo Inspector iOS SDK'
 
   s.description      = <<-DESC

--- a/AvoInspector/Classes/AvoEventSpecFetcher.h
+++ b/AvoInspector/Classes/AvoEventSpecFetcher.h
@@ -10,11 +10,11 @@ typedef void (^AvoEventSpecFetchCompletion)(AvoEventSpecResponse * _Nullable res
 @interface AvoEventSpecFetcher : NSObject
 
 - (instancetype)initWithTimeout:(NSTimeInterval)timeout
-                            env:(NSString *)env NS_DESIGNATED_INITIALIZER;
+                            env:(NSString *)env;
 
 - (instancetype)initWithTimeout:(NSTimeInterval)timeout
                             env:(NSString *)env
-                        baseUrl:(NSString *)baseUrl;
+                        baseUrl:(NSString *)baseUrl NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/AvoInspector/Classes/AvoInspector.m
+++ b/AvoInspector/Classes/AvoInspector.m
@@ -134,7 +134,7 @@ static const NSTimeInterval EVENT_SPEC_FETCH_TIMEOUT = 5.0;
 
         self.appName = [[NSBundle mainBundle] infoDictionary][(NSString *)kCFBundleIdentifierKey];
         self.appVersion = [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"];
-        self.libVersion = @"2.1.0";
+        self.libVersion = @"2.2.0";
 
         self.notificationCenter = [NSNotificationCenter defaultCenter];
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Analytics (3.6.10)
-  - AvoInspector (2.1.0)
+  - AvoInspector (2.2.0)
   - Expecta (1.0.6)
   - "Expecta+Snapshots (3.1.1)":
     - Expecta (~> 1.0)
@@ -38,7 +38,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Analytics: 63744ad4afa65c3bcdcdb7a94b62515bde5b3900
-  AvoInspector: ada987098ac1dedc4ae69e88a8d13fc4951bc9c0
+  AvoInspector: b72b22baa0b27fb8ec1e18dc74fb56e60572bc70
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   "Expecta+Snapshots": dcff217eef506dabd6dfdc7864ea2da321fafbb8
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a

--- a/Example/Pods/Local Podspecs/AvoInspector.podspec.json
+++ b/Example/Pods/Local Podspecs/AvoInspector.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "AvoInspector",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "summary": "Avo Inspector iOS SDK",
   "description": "A powerful suite of features that analyze your current state of tracking and guide you to a more consistent and reliable tracking process across your teams, products, and platforms.",
   "homepage": "https://github.com/avohq/ios-avo-inspector",
@@ -13,7 +13,7 @@
   },
   "source": {
     "git": "https://github.com/avohq/ios-avo-inspector.git",
-    "tag": "2.1.0"
+    "tag": "2.2.0"
   },
   "platforms": {
     "ios": "12.0"

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,6 +1,6 @@
 PODS:
   - Analytics (3.6.10)
-  - AvoInspector (2.1.0)
+  - AvoInspector (2.2.0)
   - Expecta (1.0.6)
   - "Expecta+Snapshots (3.1.1)":
     - Expecta (~> 1.0)
@@ -38,7 +38,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Analytics: 63744ad4afa65c3bcdcdb7a94b62515bde5b3900
-  AvoInspector: ada987098ac1dedc4ae69e88a8d13fc4951bc9c0
+  AvoInspector: b72b22baa0b27fb8ec1e18dc74fb56e60572bc70
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   "Expecta+Snapshots": dcff217eef506dabd6dfdc7864ea2da321fafbb8
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a

--- a/Example/Pods/Target Support Files/AvoInspector/AvoInspector-Info.plist
+++ b/Example/Pods/Target Support Files/AvoInspector/AvoInspector-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>2.1.0</string>
+  <string>2.2.0</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/Pods/Target Support Files/AvoInspector/ResourceBundle-AvoInspector-AvoInspector-Info.plist
+++ b/Example/Pods/Target Support Files/AvoInspector/ResourceBundle-AvoInspector-AvoInspector-Info.plist
@@ -13,7 +13,7 @@
   <key>CFBundlePackageType</key>
   <string>BNDL</string>
   <key>CFBundleShortVersionString</key>
-  <string>2.1.0</string>
+  <string>2.2.0</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>


### PR DESCRIPTION
## What changed?

Bump podspec version from 2.1.0 to 2.2.0 for the new CocoaPods release.

### New in 2.2.0 (since 2.1.0):
- **Event spec fetching and validation** — fetches event specs from Avo backend, validates tracked events against specs, caches specs locally
- **ECIES property value encryption** — encrypts event property values (P-256 + AES-256-GCM) before sending to the `/inspector/v1/track` endpoint in dev/staging environments
- **CI improvements** — dynamic simulator discovery for reliable CI test runs

## How to test this PR:

- Verify `AvoInspector.podspec` has `s.version = '2.2.0'`
- `pod lib lint AvoInspector.podspec` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 2.2.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->