### PR TITLE
fix: cancel timed-out network tasks and copy eventProperties in async block

### DIFF
--- a/AvoInspector.podspec
+++ b/AvoInspector.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'AvoInspector'
-  s.version          = '2.2.0'
+  s.version          = '2.2.1'
   s.summary          = 'Avo Inspector iOS SDK'
 
   s.description      = <<-DESC

--- a/AvoInspector/Classes/AvoEventSpecFetchTypes.m
+++ b/AvoInspector/Classes/AvoEventSpecFetchTypes.m
@@ -11,7 +11,7 @@
 - (instancetype)initWithDictionary:(NSDictionary *)dict {
     self = [super init];
     if (self) {
-        _t = dict[@"t"];
+        _t = dict[@"t"] ?: @"";
         _r = [dict[@"r"] boolValue];
         _l = dict[@"l"];
 
@@ -40,9 +40,9 @@
 - (instancetype)initWithDictionary:(NSDictionary *)dict {
     self = [super init];
     if (self) {
-        _b = dict[@"b"];
-        _eventId = dict[@"id"];
-        _vids = dict[@"vids"];
+        _b = dict[@"b"] ?: @"";
+        _eventId = dict[@"id"] ?: @"";
+        _vids = dict[@"vids"] ?: @[];
 
         NSDictionary *propsDict = dict[@"p"];
         if (propsDict) {
@@ -66,9 +66,9 @@
 - (instancetype)initWithDictionary:(NSDictionary *)dict {
     self = [super init];
     if (self) {
-        _schemaId = dict[@"schemaId"];
-        _branchId = dict[@"branchId"];
-        _latestActionId = dict[@"latestActionId"];
+        _schemaId = dict[@"schemaId"] ?: @"";
+        _branchId = dict[@"branchId"] ?: @"";
+        _latestActionId = dict[@"latestActionId"] ?: @"";
         _sourceId = dict[@"sourceId"];
     }
     return self;

--- a/AvoInspector/Classes/AvoEventSpecFetcher.m
+++ b/AvoInspector/Classes/AvoEventSpecFetcher.m
@@ -184,7 +184,10 @@
     }];
     [task resume];
 
-    dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(self.timeout * NSEC_PER_SEC)));
+    long waitResult = dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(self.timeout * NSEC_PER_SEC)));
+    if (waitResult != 0) {
+        [task cancel];
+    }
 
     return wireResponse;
 }

--- a/AvoInspector/Classes/AvoInspector.m
+++ b/AvoInspector/Classes/AvoInspector.m
@@ -134,7 +134,7 @@ static const NSTimeInterval EVENT_SPEC_FETCH_TIMEOUT = 5.0;
 
         self.appName = [[NSBundle mainBundle] infoDictionary][(NSString *)kCFBundleIdentifierKey];
         self.appVersion = [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"];
-        self.libVersion = @"2.2.0";
+        self.libVersion = @"2.2.1";
 
         self.notificationCenter = [NSNotificationCenter defaultCenter];
 

--- a/AvoInspector/Classes/AvoInspector.m
+++ b/AvoInspector/Classes/AvoInspector.m
@@ -357,6 +357,7 @@ static const NSTimeInterval EVENT_SPEC_FETCH_TIMEOUT = 5.0;
 
     // Defensive copy to prevent caller mutations affecting async validation
     NSDictionary *capturedParams = [params copy];
+    NSDictionary *capturedEventProperties = eventProperties != nil ? [eventProperties copy] : nil;
 
     __weak AvoInspector *weakSelf = self;
     [self.eventSpecFetcher fetchEventSpec:fetchParams completion:^(AvoEventSpecResponse * _Nullable specResponse) {
@@ -373,10 +374,10 @@ static const NSTimeInterval EVENT_SPEC_FETCH_TIMEOUT = 5.0;
             // Validate and send the validated event
             AvoValidationResult *validationResult = [AvoEventValidator validateEvent:capturedParams specResponse:specResponse];
             if (validationResult != nil) {
-                [strongSelf sendEventWithValidation:eventName schema:schema eventId:eventId eventHash:eventHash validationResult:validationResult eventProperties:eventProperties];
+                [strongSelf sendEventWithValidation:eventName schema:schema eventId:eventId eventHash:eventHash validationResult:validationResult eventProperties:capturedEventProperties];
             } else {
                 // Validation returned nil — send through batched path
-                [strongSelf internalTrackSchema:eventName eventSchema:schema eventId:eventId eventHash:eventHash eventProperties:eventProperties];
+                [strongSelf internalTrackSchema:eventName eventSchema:schema eventId:eventId eventHash:eventHash eventProperties:capturedEventProperties];
             }
         } else {
             // Cache nil to avoid re-fetching within TTL, send through batched path
@@ -384,7 +385,7 @@ static const NSTimeInterval EVENT_SPEC_FETCH_TIMEOUT = 5.0;
             if ([AvoInspector isLogging]) {
                 NSLog(@"[avo] Avo Inspector: Event spec fetch returned nil for event: %@. Cached empty response. Sending without validation.", eventName);
             }
-            [strongSelf internalTrackSchema:eventName eventSchema:schema eventId:eventId eventHash:eventHash eventProperties:eventProperties];
+            [strongSelf internalTrackSchema:eventName eventSchema:schema eventId:eventId eventHash:eventHash eventProperties:capturedEventProperties];
         }
     }];
 }


### PR DESCRIPTION
## Summary
- **Cancel timed-out network tasks**: In `AvoEventSpecFetcher.makeRequest:`, the semaphore wait result is now checked. If the wait times out, the `NSURLSessionDataTask` is explicitly cancelled to prevent leaked connections and wasted resources.
- **Copy eventProperties in async block**: In `AvoInspector.fetchAndValidateAsync:`, `eventProperties` is now defensively copied (as `capturedEventProperties`) before being used inside the async `fetchEventSpec:` completion block, preventing potential mutation by the caller between dispatch and execution.

## Test plan
- [ ] Verify event spec fetching still works in dev/staging environments
- [ ] Confirm timed-out requests are properly cancelled (observable via network logging)
- [ ] Verify eventProperties are correctly passed through in validated and non-validated event paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved network request reliability by ensuring resources are properly cleaned up when requests exceed timeout limits, preventing orphaned operations.
  * Enhanced event validation robustness by implementing defensive data handling during asynchronous processing, preventing concurrent modification issues in event tracking workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->