### PR TITLE
fix: empty nested dictionaries break schema extraction

### DIFF
--- a/AvoInspector.podspec
+++ b/AvoInspector.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'AvoInspector'
-  s.version          = '2.2.1'
+  s.version          = '2.2.2'
   s.summary          = 'Avo Inspector iOS SDK'
 
   s.description      = <<-DESC

--- a/AvoInspector/Classes/AvoInspector.m
+++ b/AvoInspector/Classes/AvoInspector.m
@@ -134,7 +134,7 @@ static const NSTimeInterval EVENT_SPEC_FETCH_TIMEOUT = 5.0;
 
         self.appName = [[NSBundle mainBundle] infoDictionary][(NSString *)kCFBundleIdentifierKey];
         self.appVersion = [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"];
-        self.libVersion = @"2.2.1";
+        self.libVersion = @"2.2.2";
 
         self.notificationCenter = [NSNotificationCenter defaultCenter];
 

--- a/AvoInspector/Classes/eventschematypes/AvoObject.m
+++ b/AvoInspector/Classes/eventschematypes/AvoObject.m
@@ -28,7 +28,9 @@
             objectSchema = [objectSchema stringByAppendingString:[NSString stringWithFormat:@"\"%@\",", [[self.fields valueForKey:fieldKey] name]]];
         }
     }
-    objectSchema = [objectSchema substringToIndex:[objectSchema length] - 1];
+    if ([self.fields count] > 0) {
+        objectSchema = [objectSchema substringToIndex:[objectSchema length] - 1];
+    }
     objectSchema = [objectSchema stringByAppendingString:@"}"];
     
     return [NSString stringWithFormat:@"%@", objectSchema];

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Analytics (3.6.10)
-  - AvoInspector (2.2.0)
+  - AvoInspector (2.2.2)
   - Expecta (1.0.6)
   - "Expecta+Snapshots (3.1.1)":
     - Expecta (~> 1.0)
@@ -38,7 +38,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Analytics: 63744ad4afa65c3bcdcdb7a94b62515bde5b3900
-  AvoInspector: b72b22baa0b27fb8ec1e18dc74fb56e60572bc70
+  AvoInspector: 2afb6f57962f2c371029b7c5e9451d4588b9e602
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   "Expecta+Snapshots": dcff217eef506dabd6dfdc7864ea2da321fafbb8
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a

--- a/Example/Pods/Local Podspecs/AvoInspector.podspec.json
+++ b/Example/Pods/Local Podspecs/AvoInspector.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "AvoInspector",
-  "version": "2.2.0",
+  "version": "2.2.2",
   "summary": "Avo Inspector iOS SDK",
   "description": "A powerful suite of features that analyze your current state of tracking and guide you to a more consistent and reliable tracking process across your teams, products, and platforms.",
   "homepage": "https://github.com/avohq/ios-avo-inspector",
@@ -13,7 +13,7 @@
   },
   "source": {
     "git": "https://github.com/avohq/ios-avo-inspector.git",
-    "tag": "2.2.0"
+    "tag": "2.2.2"
   },
   "platforms": {
     "ios": "12.0"

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,6 +1,6 @@
 PODS:
   - Analytics (3.6.10)
-  - AvoInspector (2.2.0)
+  - AvoInspector (2.2.2)
   - Expecta (1.0.6)
   - "Expecta+Snapshots (3.1.1)":
     - Expecta (~> 1.0)
@@ -38,7 +38,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Analytics: 63744ad4afa65c3bcdcdb7a94b62515bde5b3900
-  AvoInspector: b72b22baa0b27fb8ec1e18dc74fb56e60572bc70
+  AvoInspector: 2afb6f57962f2c371029b7c5e9451d4588b9e602
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   "Expecta+Snapshots": dcff217eef506dabd6dfdc7864ea2da321fafbb8
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a

--- a/Example/Pods/Target Support Files/AvoInspector/AvoInspector-Info.plist
+++ b/Example/Pods/Target Support Files/AvoInspector/AvoInspector-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>2.2.0</string>
+  <string>2.2.2</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/Pods/Target Support Files/AvoInspector/ResourceBundle-AvoInspector-AvoInspector-Info.plist
+++ b/Example/Pods/Target Support Files/AvoInspector/ResourceBundle-AvoInspector-AvoInspector-Info.plist
@@ -13,7 +13,7 @@
   <key>CFBundlePackageType</key>
   <string>BNDL</string>
   <key>CFBundleShortVersionString</key>
-  <string>2.2.0</string>
+  <string>2.2.2</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/Tests/DictionarySchemaExtractionTests.m
+++ b/Example/Tests/DictionarySchemaExtractionTests.m
@@ -95,6 +95,23 @@ it(@"can extract nullable string int float boolean list(string) object{field0:st
    .to.equal( @"{\"strKey\":\"string\",\"intKey\":\"int\",\"nullStrKey\":\"null\",\"nestedObjKey\":{\"field0\":\"string\",\"filed1\":\"int\",\"filed3\":\"list(null)\"},\"listKey\":\"list(string)\",\"boolKey\":\"boolean\",\"floatKey\":\"float\"}");
 });
 
+it(@"can extract empty nested dictionary", ^{
+    NSMutableDictionary * testParams = [NSMutableDictionary new];
+
+    NSMutableDictionary * userDict = [NSMutableDictionary new];
+    [userDict setValue:@"Alex" forKey:@"name"];
+    [userDict setValue:@{} forKey:@"experiments"];
+
+    [testParams setObject:userDict forKey:@"user"];
+
+    NSDictionary * extractedSchema = [sut extractSchema:testParams];
+
+    AvoObject * userSchema = [extractedSchema objectForKey:@"user"];
+    expect([userSchema class]).equal([AvoObject class]);
+    expect([userSchema name]).to.contain(@"\"name\":\"string\"");
+    expect([userSchema name]).to.contain(@"\"experiments\":{}");
+});
+
 it(@"can extract list with double nested objects", ^{
     NSMutableDictionary * testParams = [NSMutableDictionary new];
    


### PR DESCRIPTION
## Summary

- Empty dictionaries (e.g. `experiments = {}`) caused `AvoObject.name` to produce invalid JSON (`"}"` instead of `"{}"`), which silently broke network serialization and dropped `propertyType`/`children` for the parent object.
- Added guard in `AvoObject.m` to only strip trailing comma when fields were actually appended.
- Bumped version to 2.2.2.

## Test plan

- [x] Added test case for empty nested dictionary schema extraction
- [x] All existing tests pass
- [x] Verify `pod lib lint AvoInspector.podspec` passes before publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to 2.2.2 across package configurations.

* **Bug Fixes**
  * Fixed handling of empty nested dictionaries in schema extraction to prevent invalid operations.

* **Tests**
  * Added test coverage for empty nested dictionary extraction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->