### PR TITLE
fix: mitigate ReDoS vulnerability with timeout + pattern validation

### DIFF
--- a/AvoInspector/Classes/AvoEventValidator.h
+++ b/AvoInspector/Classes/AvoEventValidator.h
@@ -20,6 +20,15 @@ NS_ASSUME_NONNULL_BEGIN
 + (AvoValidationResult * _Nullable)validateEvent:(NSDictionary<NSString *, id> *)properties
                                      specResponse:(AvoEventSpecResponse *)specResponse;
 
+/// Check if a regex pattern contains nested quantifiers that could cause ReDoS.
++ (BOOL)isPatternPotentiallyDangerous:(NSString *)pattern;
+
+/// Execute regex matching with a timeout to prevent ReDoS.
+/// Returns NSNotFound if the operation times out.
++ (NSUInteger)safeNumberOfMatchesWithRegex:(NSRegularExpression *)regex
+                                  inString:(NSString *)string
+                                   timeout:(NSTimeInterval)timeout;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AvoInspector/Classes/AvoEventValidator.m
+++ b/AvoInspector/Classes/AvoEventValidator.m
@@ -569,10 +569,14 @@ static NSCache *allowedValuesCache = nil;
                                    timeout:(NSTimeInterval)timeout {
     __block NSUInteger result = NSNotFound;
 
-    dispatch_queue_t queue = dispatch_queue_create("com.avo.inspector.regex", DISPATCH_QUEUE_SERIAL);
+    static dispatch_queue_t regexQueue;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        regexQueue = dispatch_queue_create("com.avo.inspector.regex", DISPATCH_QUEUE_SERIAL);
+    });
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-    dispatch_async(queue, ^{
+    dispatch_async(regexQueue, ^{
         result = [regex numberOfMatchesInString:string
                                         options:0
                                           range:NSMakeRange(0, string.length)];

--- a/Example/Tests/AvoEventValidatorTests.m
+++ b/Example/Tests/AvoEventValidatorTests.m
@@ -360,6 +360,73 @@ describe(@"AvoEventValidator", ^{
         });
     });
 
+    describe(@"ReDoS protection", ^{
+        it(@"rejects dangerous patterns with nested quantifiers", ^{
+            BOOL dangerous = [AvoEventValidator isPatternPotentiallyDangerous:@"(a+)+$"];
+            expect(dangerous).to.beTruthy();
+
+            BOOL dangerous2 = [AvoEventValidator isPatternPotentiallyDangerous:@"(.*)*"];
+            expect(dangerous2).to.beTruthy();
+
+            BOOL dangerous3 = [AvoEventValidator isPatternPotentiallyDangerous:@"([a-z]+)*"];
+            expect(dangerous3).to.beTruthy();
+        });
+
+        it(@"allows safe patterns", ^{
+            BOOL safe1 = [AvoEventValidator isPatternPotentiallyDangerous:@"^[0-9]+$"];
+            expect(safe1).to.beFalsy();
+
+            BOOL safe2 = [AvoEventValidator isPatternPotentiallyDangerous:@"^[a-zA-Z]{1,100}$"];
+            expect(safe2).to.beFalsy();
+
+            BOOL safe3 = [AvoEventValidator isPatternPotentiallyDangerous:@"\\d+\\.\\d+"];
+            expect(safe3).to.beFalsy();
+        });
+
+        it(@"completes ReDoS input within 5 seconds even for evil pattern", ^{
+            // Even if a dangerous pattern somehow gets through the static check,
+            // the timeout mechanism should catch it at 2s.
+            // Build a known-evil regex manually for this test.
+            NSRegularExpression *evilRegex =
+                [NSRegularExpression regularExpressionWithPattern:@"(a+)+$" options:0 error:nil];
+
+            // Build a string that triggers catastrophic backtracking
+            NSMutableString *evilInput = [NSMutableString string];
+            for (int i = 0; i < 20000; i++) {
+                [evilInput appendString:@"a"];
+            }
+            [evilInput appendString:@"!"];
+
+            NSDate *start = [NSDate date];
+            NSUInteger result = [AvoEventValidator safeNumberOfMatchesWithRegex:evilRegex
+                                                                      inString:evilInput
+                                                                       timeout:2.0];
+            NSTimeInterval elapsed = -[start timeIntervalSinceNow];
+
+            // Should have timed out (returned NSNotFound) well under 5 seconds
+            expect(elapsed).to.beLessThan(5.0);
+            expect(result).to.equal(NSNotFound);
+        });
+
+        it(@"skips constraint for dangerous regex pattern in validation", ^{
+            // Use a dangerous pattern — should be rejected and constraint skipped
+            AvoPropertyConstraints *constraint = makeConstraints(@"string",
+                nil, nil, @{@"(a+)+$": @[@"evt1"]}, nil);
+
+            AvoEventSpecEntry *entry = makeEntry(@"b1", @"evt1", @[], @{@"prop": constraint});
+            AvoEventSpecResponse *resp = makeResponse(@[entry]);
+
+            // Even though the value doesn't match, the dangerous pattern is skipped
+            AvoValidationResult *result = [AvoEventValidator validateEvent:@{@"prop": @"test"} specResponse:resp];
+            expect(result).toNot.beNil();
+            // No failure because the constraint was skipped
+            AvoPropertyValidationResult *propResult = result.propertyResults[@"prop"];
+            expect(propResult).toNot.beNil();
+            expect(propResult.failedEventIds).to.beNil();
+            expect(propResult.passedEventIds).to.beNil();
+        });
+    });
+
     describe(@"Metadata", ^{
         it(@"includes metadata in validation result", ^{
             AvoPropertyConstraints *constraint = makeConstraints(@"string",


### PR DESCRIPTION
## Summary

- Add defense-in-depth ReDoS protection for regex pattern matching in AvoEventValidator
- **Pattern validator**: `isPatternPotentiallyDangerous:` rejects patterns with nested quantifiers (e.g. `(a+)+$`) before compilation
- **Timeout wrapper**: `safeNumberOfMatchesWithRegex:inString:timeout:` uses GCD semaphore with 2-second timeout as safety net
- Fail-open: timed-out or rejected patterns skip the constraint (no false positives)

## Why

`NSRegularExpression` uses ICU's backtracking engine. A malicious or compromised pattern like `(a+)+$` matched against a long string causes exponential CPU usage (ReDoS). No good RE2 library exists for Objective-C without heavy C++ dependencies, so we use a timeout + pattern validation approach instead.

## Changes

| File | Change |
|------|--------|
| `AvoEventValidator.h` | Declare new protection methods |
| `AvoEventValidator.m` | Add `isPatternPotentiallyDangerous:`, `safeNumberOfMatchesWithRegex:inString:timeout:`, update callers |
| `AvoEventValidatorTests.m` | Add 4 tests: dangerous pattern rejection, safe pattern allowance, timeout safety, end-to-end skip |

## Test plan

- [x] Dangerous patterns `(a+)+$`, `(.*)*`, `([a-z]+)*` rejected by pre-check
- [x] Safe patterns `^[0-9]+$`, `^[a-zA-Z]{1,100}$` pass pre-check
- [x] Timeout returns `NSNotFound` within 5 seconds for evil input
- [x] End-to-end: dangerous regex constraint silently skipped during validation
- [ ] Existing test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented timeout protection for regex operations to prevent application hangs
  * Added automatic detection and rejection of potentially dangerous regex patterns
  * Improved error handling and logging for regex-related operations

* **Tests**
  * Added comprehensive test coverage for regex safety features and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->